### PR TITLE
updated deletAll function for DeviceStorageDatadsource that removes a…

### DIFF
--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/srpreferences/DeviceStorageDataSource.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/srpreferences/DeviceStorageDataSource.kt
@@ -78,9 +78,14 @@ class DeviceStorageDataSource<T> @Inject constructor(
   }
 
   override fun deleteAll(query: Query): Future<Unit> = Future {
-    sharedPreferences.edit()
-        .clear()
-        .apply()
+    if (prefix.isNotEmpty()) {
+      val editor = sharedPreferences.edit()
+      sharedPreferences.all.keys.filter { it.contains(prefix) }.forEach { editor.remove(it) }
+      editor.apply()
+    } else {
+      sharedPreferences.edit().clear().apply()
+    }
+
   }
 
   private fun addPrefixTo(key: String) = if (prefix.isEmpty()) key else "$prefix.$key"

--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/srpreferences/DeviceStorageDataSource.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/srpreferences/DeviceStorageDataSource.kt
@@ -78,12 +78,13 @@ class DeviceStorageDataSource<T> @Inject constructor(
   }
 
   override fun deleteAll(query: Query): Future<Unit> = Future {
-    if (prefix.isNotEmpty()) {
-      val editor = sharedPreferences.edit()
-      sharedPreferences.all.keys.filter { it.contains(prefix) }.forEach { editor.remove(it) }
-      editor.apply()
-    } else {
-      sharedPreferences.edit().clear().apply()
+    with(sharedPreferences.edit()) {
+      if (prefix.isNotEmpty()) {
+        sharedPreferences.all.keys.filter { it.contains(prefix) }.forEach { remove(it) }
+      } else {
+        clear()
+      }
+      apply()
     }
 
   }

--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/srpreferences/DeviceStorageDataSource.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/srpreferences/DeviceStorageDataSource.kt
@@ -78,14 +78,9 @@ class DeviceStorageDataSource<T> @Inject constructor(
   }
 
   override fun deleteAll(query: Query): Future<Unit> = Future {
-    when (query) {
-      is KeyQuery -> {
-        sharedPreferences.edit()
-            .remove(addPrefixTo(query.key))
-            .apply()
-      }
-      else -> notSupportedQuery()
-    }
+    sharedPreferences.edit()
+        .clear()
+        .apply()
   }
 
   private fun addPrefixTo(key: String) = if (prefix.isEmpty()) key else "$prefix.$key"

--- a/sample/src/main/java/com/mobilejazz/sample/di/general/ItemDI.kt
+++ b/sample/src/main/java/com/mobilejazz/sample/di/general/ItemDI.kt
@@ -47,7 +47,7 @@ class ItemDI {
   @Provides
   @Singleton
   fun provideSharedPreferencesStorage(sharedPreferences: SharedPreferences): DeviceStorageObjectAssemblerDataSource<ItemEntity> {
-    val deviceStorageDataSource = DeviceStorageDataSource<String>(sharedPreferences, "items")
+    val deviceStorageDataSource = DeviceStorageDataSource<String>(sharedPreferences)
 
     val gson = Gson()
     val toStringMapper = ModelToStringMapper<ItemEntity>(gson)

--- a/sample/src/main/java/com/mobilejazz/sample/di/general/ItemDI.kt
+++ b/sample/src/main/java/com/mobilejazz/sample/di/general/ItemDI.kt
@@ -47,7 +47,7 @@ class ItemDI {
   @Provides
   @Singleton
   fun provideSharedPreferencesStorage(sharedPreferences: SharedPreferences): DeviceStorageObjectAssemblerDataSource<ItemEntity> {
-    val deviceStorageDataSource = DeviceStorageDataSource<String>(sharedPreferences)
+    val deviceStorageDataSource = DeviceStorageDataSource<String>(sharedPreferences, "items")
 
     val gson = Gson()
     val toStringMapper = ModelToStringMapper<ItemEntity>(gson)


### PR DESCRIPTION
I've updated the deletaAll function to fully remove the shared preferences. Does it make sense for you? The context:

I was thinking on how to implement a logout functionality and the first thought I had was to fully remove everything from the device and after looking on how deletaAll looks like inside de DeviceStorageDatasource I realized that it's exactly the same as delete so I updated it. 

Let me know what you think and wether we can merge it to develop.