### PR TITLE
Fixing TimestampValidationStrategy <-> gson impcompabibility

### DIFF
--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/validator/vastra/strategies/timestamp/TimestampValidationStrategy.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/validator/vastra/strategies/timestamp/TimestampValidationStrategy.kt
@@ -5,7 +5,15 @@ import com.mobilejazz.harmony.kotlin.core.repository.validator.vastra.strategies
 import com.mobilejazz.harmony.kotlin.core.repository.validator.vastra.strategies.ValidationStrategyResult
 import java.util.*
 
-abstract class TimestampValidationStrategyDataSource(open var lastUpdate: Date = Date(), open var expiryTime: Long) : ValidationStrategyDataSource
+abstract class TimestampValidationStrategyDataSource(lastUpdate: Date = Date()) : ValidationStrategyDataSource {
+  private val optionalLastUpdate: Date? = lastUpdate
+
+  val lastUpdate: Date
+    get() = optionalLastUpdate ?: Date()
+
+  abstract val expiryTime: Long
+
+}
 
 class TimestampValidationStrategy : ValidationStrategy {
 

--- a/core/src/test/java/com/mobilejazz/harmony/kotlin/core/repository/validator/TimestampValidationStrategyDataSourceTest.kt
+++ b/core/src/test/java/com/mobilejazz/harmony/kotlin/core/repository/validator/TimestampValidationStrategyDataSourceTest.kt
@@ -1,0 +1,32 @@
+package com.mobilejazz.harmony.kotlin.core.repository.validator
+
+import com.google.gson.GsonBuilder
+import com.mobilejazz.harmony.kotlin.core.repository.validator.vastra.strategies.timestamp.TimestampValidationStrategyDataSource
+import org.junit.Assert
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+
+class TimestampValidationStrategyDataSourceTest {
+
+  data class TestObject(private val id: Long, private val text: String) : TimestampValidationStrategyDataSource() {
+    override val expiryTime: Long
+      get() = TimeUnit.SECONDS.toMillis(1)
+  }
+
+  @Test
+  internal fun shouldGetLastUpdateNonNullValue_WhenCreatingObjectUsingGson() {
+    val jsonTestObject = """
+      | {
+      |   "id": 123,
+      |   "text": "Sample text"
+      | }
+    """.trimMargin()
+
+    val gson = GsonBuilder().create()
+
+    val parsedObject = gson.fromJson(jsonTestObject, TestObject::class.java)
+
+    Assert.assertNotNull(parsedObject.lastUpdate)
+  }
+}


### PR DESCRIPTION
Added changes to avoid lastUpdate and expiryTime to be null when parsing using gson:

- For lastUpdate I've created an nullable private var and a custom getter to avoid the NullPointerException when accessing the field.
  - From the perspective of anyone that uses the class everything is the same as if we were using "val lastUpdate" in the constructor

- For expiryTime I changed to be an abstract member to make it possible to implement it with a custom getter instead of forcing it to be implemented as a constructor parameter.

Both changes give us the possibility to use gson without worrying about having to create a copy of the objects and assigning values each time they are parsed.