### PR TITLE
Allow to use our Base Activities and Fragment without using Dagger as DI

### DIFF
--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/ui/base/BaseActivity.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/ui/base/BaseActivity.kt
@@ -1,9 +1,11 @@
 package com.mobilejazz.harmony.kotlin.android.ui.base
 
 import android.os.Bundle
+import android.util.Log
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import com.mobilejazz.harmony.kotlin.core.ext.getStackTraceAsString
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -19,6 +21,9 @@ abstract class BaseActivity : AppCompatActivity(), HasSupportFragmentInjector {
     try {
       AndroidInjection.inject(this)
     } catch (t: Throwable) {
+      Log.d("BaseActivity",
+          "Dagger is not configured for ${this::class.java.name}. If you are not using Dagger in this Activity don't worry about this.\n" +
+              "Exception thrown by Dagger: ${t.getStackTraceAsString()}")
     }
   }
 

--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/ui/base/BaseActivity.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/ui/base/BaseActivity.kt
@@ -12,10 +12,19 @@ import javax.inject.Inject
 
 abstract class BaseActivity : AppCompatActivity(), HasSupportFragmentInjector {
 
-  @Inject lateinit var fragmentInjector: DispatchingAndroidInjector<Fragment>
+  @Inject
+  lateinit var fragmentInjector: DispatchingAndroidInjector<Fragment>
+
+  open fun injectDependencies() {
+    try {
+      AndroidInjection.inject(this)
+    } catch (t: Throwable) {
+    }
+  }
+
 
   override fun onCreate(savedInstanceState: Bundle?) {
-    AndroidInjection.inject(this)
+    injectDependencies()
     super.onCreate(savedInstanceState)
     setContentView(getContentViewResId())
   }

--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/ui/base/BaseFragment.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/ui/base/BaseFragment.kt
@@ -2,11 +2,13 @@ package com.mobilejazz.harmony.kotlin.android.ui.base
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
+import com.mobilejazz.harmony.kotlin.core.ext.getStackTraceAsString
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.support.AndroidSupportInjection
@@ -24,6 +26,9 @@ abstract class BaseFragment : Fragment(), HasSupportFragmentInjector {
     try {
       AndroidSupportInjection.inject(this)
     } catch (t: Throwable) {
+      Log.d("BaseFragment",
+          "Dagger is not configured for ${this::class.java.name}. If you are not using Dagger in this Fragment don't worry about this.\n" +
+              "Exception thrown by Dagger: ${t.getStackTraceAsString()}")
     }
   }
 

--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/ui/base/BaseFragment.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/ui/base/BaseFragment.kt
@@ -15,20 +15,27 @@ import javax.inject.Inject
 
 abstract class BaseFragment : Fragment(), HasSupportFragmentInjector {
 
-  @Inject lateinit var childFragmentInjector: DispatchingAndroidInjector<Fragment>
+  @Inject
+  lateinit var childFragmentInjector: DispatchingAndroidInjector<Fragment>
 
   override fun supportFragmentInjector(): AndroidInjector<Fragment> = childFragmentInjector
 
-  // Perform injection here for M (API 23) due to deprecation of onAttach(Activity).
+  open fun injectDependencies() {
+    try {
+      AndroidSupportInjection.inject(this)
+    } catch (t: Throwable) {
+    }
+  }
+
   override fun onAttach(context: Context) {
-    AndroidSupportInjection.inject(this)
+    injectDependencies()
     super.onAttach(context)
   }
 
   override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?
   ): View? {
     return inflater.inflate(getContentViewResId(), container, false)
   }


### PR DESCRIPTION
This is useful when we have a library in which we don't want to use Dagger but we went to use our base classes. 

For example, in the Reader library I had to duplicate all classes into the library to be able to do it (and now in PeerWell we will have a library without Dagger that will benefit from it).

The changes are not intended to remove Dagger dependencies from harmony (even they will eventually go away for kotlin multiplatform). The idea was just to provide a way of using base classes without dagger with no breaking changes.

The implemented changes were the following ones:
 - Add a open injectDependencies method to override if needed.
 - AndroidSupportInjection.inject(this) surrounded by a try/catch
 to allow usage without the need to configure Dagger