### PR TITLE
Deprecated deleteAll and redirected to delete:

### DIFF
--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/database/DatabaseStorageDataSource.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/database/DatabaseStorageDataSource.kt
@@ -9,6 +9,7 @@ import com.mobilejazz.harmony.kotlin.core.repository.datasource.DeleteDataSource
 import com.mobilejazz.harmony.kotlin.core.repository.datasource.GetDataSource
 import com.mobilejazz.harmony.kotlin.core.repository.datasource.PutDataSource
 import com.mobilejazz.harmony.kotlin.core.repository.error.DataNotFoundException
+import com.mobilejazz.harmony.kotlin.core.repository.query.AllObjectsQuery
 import com.mobilejazz.harmony.kotlin.core.repository.query.KeyQuery
 import com.mobilejazz.harmony.kotlin.core.repository.query.Query
 import com.mobilejazz.harmony.kotlin.core.threading.extensions.Future
@@ -71,6 +72,11 @@ class DatabaseStorageDataSource(private val db: SupportSQLiteDatabase) : GetData
   override fun delete(query: Query): Future<Unit> =
       Future {
         when (query) {
+          is AllObjectsQuery -> {
+            db.delete(BlobTable.TABLE_NAME, null, null)
+            return@Future
+          }
+
           is KeyQuery -> {
             db.delete(
                 BlobTable.TABLE_NAME,
@@ -84,10 +90,6 @@ class DatabaseStorageDataSource(private val db: SupportSQLiteDatabase) : GetData
       }
 
   override fun deleteAll(query: Query): Future<Unit> =
-  // TODO Options for deleteAll:
-  // - Not supported (current implementation)
-  // - Ignore query and clear database
-      // - Use a new KeysQuery(List<String>) and delete all entries with the indicated query
       Future {
         throw UnsupportedOperationException("deleteAll not supported. Use delete instead")
       }

--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/srpreferences/DeviceStorageObjectAssemblerDataSource.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/repository/datasource/srpreferences/DeviceStorageObjectAssemblerDataSource.kt
@@ -7,6 +7,7 @@ import com.mobilejazz.harmony.kotlin.core.repository.mapper.Mapper
 import com.mobilejazz.harmony.kotlin.core.repository.query.Query
 import com.mobilejazz.harmony.kotlin.core.threading.extensions.Future
 
+@Deprecated("Use SerializationDataSourceMapper to serialize/deserialize your model")
 class DeviceStorageObjectAssemblerDataSource<T>(
     private val toStringMapper: Mapper<T, String>,
     private val toModelMapper: Mapper<String, T>,

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/Repository.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/Repository.kt
@@ -28,6 +28,7 @@ interface PutRepository<V> : Repository {
 
 interface DeleteRepository : Repository {
   fun delete(query: Query, operation: Operation = DefaultOperation): Future<Unit>
+  @Deprecated("Use delete with AllObjectsQuery to remove all entries or with any other Query to remove one or more entries")
   fun deleteAll(query: Query, operation: Operation = DefaultOperation): Future<Unit>
 }
 

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/datasource/DataSource.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/datasource/DataSource.kt
@@ -29,6 +29,7 @@ interface PutDataSource<V> : DataSource {
 interface DeleteDataSource : DataSource {
   fun delete(query: Query): Future<Unit>
 
+  @Deprecated("Use delete with AllObjectsQuery to remove all entries or with any other Query to remove one or more entries")
   fun deleteAll(query: Query): Future<Unit>
 }
 

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/datasource/memory/InMemoryDataSource.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/datasource/memory/InMemoryDataSource.kt
@@ -42,6 +42,7 @@ class InMemoryDataSource<V> @Inject constructor() : GetDataSource<V>, PutDataSou
     when (query) {
       is KeyQuery -> {
         value?.let {
+          arrays.remove(query.key)
           objects.put(query.key, value).run { value }
         } ?: throw IllegalArgumentException("InMemoryDataSource: value must be not null")
       }
@@ -53,6 +54,7 @@ class InMemoryDataSource<V> @Inject constructor() : GetDataSource<V>, PutDataSou
     when (query) {
       is KeyQuery -> {
         value?.let {
+          objects.remove(query.key)
           arrays.put(query.key, value).run { value }
         } ?: throw IllegalArgumentException("InMemoryDataSource: values must be not null")
 

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/datasource/memory/InMemoryDataSource.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/repository/datasource/memory/InMemoryDataSource.kt
@@ -4,6 +4,8 @@ import com.mobilejazz.harmony.kotlin.core.repository.datasource.DeleteDataSource
 import com.mobilejazz.harmony.kotlin.core.repository.datasource.GetDataSource
 import com.mobilejazz.harmony.kotlin.core.repository.datasource.PutDataSource
 import com.mobilejazz.harmony.kotlin.core.repository.error.DataNotFoundException
+import com.mobilejazz.harmony.kotlin.core.repository.query.AllObjectsQuery
+import com.mobilejazz.harmony.kotlin.core.repository.query.IdsQuery
 import com.mobilejazz.harmony.kotlin.core.repository.query.KeyQuery
 import com.mobilejazz.harmony.kotlin.core.repository.query.Query
 import com.mobilejazz.harmony.kotlin.core.threading.extensions.Future
@@ -62,19 +64,22 @@ class InMemoryDataSource<V> @Inject constructor() : GetDataSource<V>, PutDataSou
   override fun delete(query: Query): Future<Unit> {
     return Future {
       when (query) {
-        is KeyQuery -> {
-          objects.remove(query.key)
+        is AllObjectsQuery -> {
+          objects.clear()
+          arrays.clear()
           return@Future
         }
-        else -> notSupportedQuery()
-      }
-    }
-  }
-
-  override fun deleteAll(query: Query): Future<Unit> {
-    return Future {
-      when (query) {
+        is IdsQuery<*> -> {
+          query.identifiers.forEach {
+            if (it is String) {
+              objects.remove(it)
+              arrays.remove(it)
+            } else notSupportedQuery()
+          }
+          return@Future
+        }
         is KeyQuery -> {
+          objects.remove(query.key)
           arrays.remove(query.key)
           return@Future
         }
@@ -82,4 +87,6 @@ class InMemoryDataSource<V> @Inject constructor() : GetDataSource<V>, PutDataSou
       }
     }
   }
+
+  override fun deleteAll(query: Query): Future<Unit> = delete(query)
 }


### PR DESCRIPTION
 - In the case of DatabaseStorageDatasource it throws an Exception as
 it was the previous behavior.
 - In the case of InMemoryDataSource behavior changes were needed:
  - deleteAll was used for deleting lists
  - Now delete with AllObjectsQuery will remove all objects and lists
  - Now delete with IdsQuery or KeyQuery will remove the key from both
  objects and lists map

I created this issue in reference to discuss the InMemoryDatasource changes: https://github.com/mobilejazz/harmony-reference/issues/27