### PR TITLE
Add Logger implementation

### DIFF
--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/logger/AndroidLogger.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/logger/AndroidLogger.kt
@@ -1,0 +1,95 @@
+package com.mobilejazz.harmony.kotlin.android.logger
+
+import android.os.Build
+import android.util.Log
+import com.mobilejazz.harmony.kotlin.android.BuildConfig
+import com.mobilejazz.harmony.kotlin.core.logger.Logger
+import java.util.regex.Pattern
+
+open class AndroidLogger : Logger {
+
+  companion object {
+    private const val MAX_TAG_LENGTH = 23
+    private val ANONYMOUS_CLASS = Pattern.compile("(\\$\\d+)+$")
+  }
+
+  override fun log(level: Logger.LogLevel, tag: String?, message: String) {
+    val tag = tag ?: createClassTag()
+    if (BuildConfig.DEBUG) {
+      when (level) {
+        Logger.LogLevel.VERBOSE -> Log.v(tag, message)
+        Logger.LogLevel.DEBUG -> Log.d(tag, message)
+        Logger.LogLevel.INFO -> Log.i(tag, message)
+        Logger.LogLevel.WARNING -> Log.w(tag, message)
+        Logger.LogLevel.ERROR -> Log.e(tag, message)
+      }
+    }
+  }
+
+  override fun log(level: Logger.LogLevel, throwable: Throwable, tag: String?, message: String) {
+    val tag = tag ?: createClassTag()
+    if (BuildConfig.DEBUG) {
+      when (level) {
+        Logger.LogLevel.VERBOSE -> Log.v(tag, message, throwable)
+        Logger.LogLevel.DEBUG -> Log.d(tag, message, throwable)
+        Logger.LogLevel.INFO -> Log.i(tag, message, throwable)
+        Logger.LogLevel.WARNING -> Log.w(tag, message, throwable)
+        Logger.LogLevel.ERROR -> Log.e(tag, message, throwable)
+      }
+    }
+  }
+
+  override fun log(key: String, value: Any?) {
+    value?.let {
+      log(Logger.LogLevel.INFO, "KEY", "$key: $it")
+    } ?: log(Logger.LogLevel.INFO, "KEY", "$key: null")
+  }
+
+  override fun sendIssue(tag: String, message: String) {
+    // Nothing to do
+  }
+
+  override fun setDeviceBoolean(key: String, value: Boolean) {
+    // Nothing to do
+  }
+
+  override fun setDeviceString(key: String, value: String) {
+    // Nothing to do
+  }
+
+  override fun setDeviceInteger(key: String, value: Int) {
+    // Nothing to do
+  }
+
+  override fun setDeviceFloat(key: String, value: Float) {
+    // Nothing to do
+  }
+
+  override fun removeDeviceKey(key: String) {
+    // Nothing to do
+  }
+
+  override val deviceIdentifier: String
+    get() = TODO("not implemented")
+
+  private fun createClassTag(): String? {
+    val ignoreClass = listOf(
+        AndroidLogger::class.java.name,
+        Logger::class.java.name
+    )
+    val stackTraceElement: StackTraceElement = Throwable().stackTrace
+        .first { it.className !in ignoreClass && !it.className.contains("DefaultImpls") }
+    var tag = stackTraceElement.className.substringAfterLast('.')
+    val m = ANONYMOUS_CLASS.matcher(tag)
+    if (m.find()) {
+      tag = m.replaceAll("")
+    }
+    // Tag length limit was removed in API 24.
+    return if (tag.length <= MAX_TAG_LENGTH || Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      tag
+    } else {
+      tag.substring(0, MAX_TAG_LENGTH)
+    }
+  }
+
+}

--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/logger/AndroidLogger.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/logger/AndroidLogger.kt
@@ -46,31 +46,31 @@ open class AndroidLogger : Logger {
   }
 
   override fun sendIssue(tag: String, message: String) {
-    // Nothing to do
+    log(Logger.Level.DEBUG, tag, message)
   }
 
   override fun setDeviceBoolean(key: String, value: Boolean) {
-    // Nothing to do
+    log(Logger.Level.DEBUG, key, value.toString())
   }
 
   override fun setDeviceString(key: String, value: String) {
-    // Nothing to do
+    log(Logger.Level.DEBUG, key, value)
   }
 
   override fun setDeviceInteger(key: String, value: Int) {
-    // Nothing to do
+    log(Logger.Level.DEBUG, key, value.toString())
   }
 
   override fun setDeviceFloat(key: String, value: Float) {
-    // Nothing to do
+    log(Logger.Level.DEBUG, key, value.toString())
   }
 
   override fun removeDeviceKey(key: String) {
-    // Nothing to do
+    log(Logger.Level.DEBUG, key, "RemoveDeviceKey")
   }
 
   override val deviceIdentifier: String
-    get() = TODO("not implemented")
+    get() = ""
 
   private fun createClassTag(): String? {
     val ignoreClass = listOf(

--- a/android/src/main/java/com/mobilejazz/harmony/kotlin/android/logger/AndroidLogger.kt
+++ b/android/src/main/java/com/mobilejazz/harmony/kotlin/android/logger/AndroidLogger.kt
@@ -13,36 +13,36 @@ open class AndroidLogger : Logger {
     private val ANONYMOUS_CLASS = Pattern.compile("(\\$\\d+)+$")
   }
 
-  override fun log(level: Logger.LogLevel, tag: String?, message: String) {
+  override fun log(level: Logger.Level, tag: String?, message: String) {
     val tag = tag ?: createClassTag()
     if (BuildConfig.DEBUG) {
       when (level) {
-        Logger.LogLevel.VERBOSE -> Log.v(tag, message)
-        Logger.LogLevel.DEBUG -> Log.d(tag, message)
-        Logger.LogLevel.INFO -> Log.i(tag, message)
-        Logger.LogLevel.WARNING -> Log.w(tag, message)
-        Logger.LogLevel.ERROR -> Log.e(tag, message)
+        Logger.Level.VERBOSE -> Log.v(tag, message)
+        Logger.Level.DEBUG -> Log.d(tag, message)
+        Logger.Level.INFO -> Log.i(tag, message)
+        Logger.Level.WARNING -> Log.w(tag, message)
+        Logger.Level.ERROR -> Log.e(tag, message)
       }
     }
   }
 
-  override fun log(level: Logger.LogLevel, throwable: Throwable, tag: String?, message: String) {
+  override fun log(level: Logger.Level, throwable: Throwable, tag: String?, message: String) {
     val tag = tag ?: createClassTag()
     if (BuildConfig.DEBUG) {
       when (level) {
-        Logger.LogLevel.VERBOSE -> Log.v(tag, message, throwable)
-        Logger.LogLevel.DEBUG -> Log.d(tag, message, throwable)
-        Logger.LogLevel.INFO -> Log.i(tag, message, throwable)
-        Logger.LogLevel.WARNING -> Log.w(tag, message, throwable)
-        Logger.LogLevel.ERROR -> Log.e(tag, message, throwable)
+        Logger.Level.VERBOSE -> Log.v(tag, message, throwable)
+        Logger.Level.DEBUG -> Log.d(tag, message, throwable)
+        Logger.Level.INFO -> Log.i(tag, message, throwable)
+        Logger.Level.WARNING -> Log.w(tag, message, throwable)
+        Logger.Level.ERROR -> Log.e(tag, message, throwable)
       }
     }
   }
 
   override fun log(key: String, value: Any?) {
     value?.let {
-      log(Logger.LogLevel.INFO, "KEY", "$key: $it")
-    } ?: log(Logger.LogLevel.INFO, "KEY", "$key: null")
+      log(Logger.Level.INFO, "KEY", "$key: $it")
+    } ?: log(Logger.Level.INFO, "KEY", "$key: null")
   }
 
   override fun sendIssue(tag: String, message: String) {

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/ConsoleLogger.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/ConsoleLogger.kt
@@ -5,8 +5,8 @@ class ConsoleLogger : Logger {
 
   override fun log(level: Logger.Level, tag: String?, message: String) {
     tag?.let {
-      println("${level.levelStringRepresentation()} - [$it]: $message")
-    } ?: println("${level.levelStringRepresentation()}: $message")
+      println("${level.representation} - [$it]: $message")
+    } ?: println("${level.representation}: $message")
   }
 
   override fun log(level: Logger.Level, throwable: Throwable, tag: String?, message: String) {
@@ -46,14 +46,4 @@ class ConsoleLogger : Logger {
 
   override val deviceIdentifier: String
     get() = ""
-
-  private fun Logger.Level.levelStringRepresentation(): String {
-    return when (this) {
-      Logger.Level.VERBOSE -> "VERBOSE"
-      Logger.Level.DEBUG -> "DEBUG"
-      Logger.Level.INFO -> "INFO"
-      Logger.Level.WARNING -> "WARNING"
-      Logger.Level.ERROR -> "ERROR"
-    }
-  }
 }

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/ConsoleLogger.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/ConsoleLogger.kt
@@ -21,31 +21,31 @@ class ConsoleLogger : Logger {
   }
 
   override fun sendIssue(tag: String, message: String) {
-    // Nothing to do
+    this.log(Logger.Level.DEBUG, tag, message)
   }
 
   override fun setDeviceBoolean(key: String, value: Boolean) {
-    // Nothing to do
+    this.log(Logger.Level.DEBUG, key, value.toString())
   }
 
   override fun setDeviceString(key: String, value: String) {
-    // Nothing to do
+    this.log(Logger.Level.DEBUG, key, value)
   }
 
   override fun setDeviceInteger(key: String, value: Int) {
-    // Nothing to do
+    this.log(Logger.Level.DEBUG, key, value.toString())
   }
 
   override fun setDeviceFloat(key: String, value: Float) {
-    // Nothing to do
+    this.log(Logger.Level.DEBUG, key, value.toString())
   }
 
   override fun removeDeviceKey(key: String) {
-    // Nothing to do
+    this.log(Logger.Level.DEBUG, "RemoveDeviceKey", key)
   }
 
   override val deviceIdentifier: String
-    get() = TODO("not implemented")
+    get() = ""
 
   private fun Logger.Level.levelStringRepresentation(): String {
     return when (this) {

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/ConsoleLogger.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/ConsoleLogger.kt
@@ -1,0 +1,59 @@
+package com.mobilejazz.harmony.kotlin.core.logger
+
+
+class ConsoleLogger : Logger {
+
+  override fun log(level: Logger.LogLevel, tag: String?, message: String) {
+    tag?.let {
+      println("${level.levelStringRepresentation()} - [$it]: $message")
+    } ?: println("${level.levelStringRepresentation()}: $message")
+  }
+
+  override fun log(level: Logger.LogLevel, throwable: Throwable, tag: String?, message: String) {
+    log(level, tag, message)
+    throwable.printStackTrace()
+  }
+
+  override fun log(key: String, value: Any?) {
+    value?.let {
+      log(Logger.LogLevel.INFO, "KEY", "$key: $it")
+    } ?: log(Logger.LogLevel.INFO, "KEY", "$key: null")
+  }
+
+  override fun sendIssue(tag: String, message: String) {
+    // Nothing to do
+  }
+
+  override fun setDeviceBoolean(key: String, value: Boolean) {
+    // Nothing to do
+  }
+
+  override fun setDeviceString(key: String, value: String) {
+    // Nothing to do
+  }
+
+  override fun setDeviceInteger(key: String, value: Int) {
+    // Nothing to do
+  }
+
+  override fun setDeviceFloat(key: String, value: Float) {
+    // Nothing to do
+  }
+
+  override fun removeDeviceKey(key: String) {
+    // Nothing to do
+  }
+
+  override val deviceIdentifier: String
+    get() = TODO("not implemented")
+
+  private fun Logger.LogLevel.levelStringRepresentation(): String {
+    return when (this) {
+      Logger.LogLevel.VERBOSE -> "VERBOSE"
+      Logger.LogLevel.DEBUG -> "DEBUG"
+      Logger.LogLevel.INFO -> "INFO"
+      Logger.LogLevel.WARNING -> "WARNING"
+      Logger.LogLevel.ERROR -> "ERROR"
+    }
+  }
+}

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/ConsoleLogger.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/ConsoleLogger.kt
@@ -3,21 +3,21 @@ package com.mobilejazz.harmony.kotlin.core.logger
 
 class ConsoleLogger : Logger {
 
-  override fun log(level: Logger.LogLevel, tag: String?, message: String) {
+  override fun log(level: Logger.Level, tag: String?, message: String) {
     tag?.let {
       println("${level.levelStringRepresentation()} - [$it]: $message")
     } ?: println("${level.levelStringRepresentation()}: $message")
   }
 
-  override fun log(level: Logger.LogLevel, throwable: Throwable, tag: String?, message: String) {
+  override fun log(level: Logger.Level, throwable: Throwable, tag: String?, message: String) {
     log(level, tag, message)
     throwable.printStackTrace()
   }
 
   override fun log(key: String, value: Any?) {
     value?.let {
-      log(Logger.LogLevel.INFO, "KEY", "$key: $it")
-    } ?: log(Logger.LogLevel.INFO, "KEY", "$key: null")
+      log(Logger.Level.INFO, "KEY", "$key: $it")
+    } ?: log(Logger.Level.INFO, "KEY", "$key: null")
   }
 
   override fun sendIssue(tag: String, message: String) {
@@ -47,13 +47,13 @@ class ConsoleLogger : Logger {
   override val deviceIdentifier: String
     get() = TODO("not implemented")
 
-  private fun Logger.LogLevel.levelStringRepresentation(): String {
+  private fun Logger.Level.levelStringRepresentation(): String {
     return when (this) {
-      Logger.LogLevel.VERBOSE -> "VERBOSE"
-      Logger.LogLevel.DEBUG -> "DEBUG"
-      Logger.LogLevel.INFO -> "INFO"
-      Logger.LogLevel.WARNING -> "WARNING"
-      Logger.LogLevel.ERROR -> "ERROR"
+      Logger.Level.VERBOSE -> "VERBOSE"
+      Logger.Level.DEBUG -> "DEBUG"
+      Logger.Level.INFO -> "INFO"
+      Logger.Level.WARNING -> "WARNING"
+      Logger.Level.ERROR -> "ERROR"
     }
   }
 }

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/Logger.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/Logger.kt
@@ -3,7 +3,7 @@ package com.mobilejazz.harmony.kotlin.core.logger
 /** Logging interface.  */
 interface Logger {
 
-  enum class LogLevel {
+  enum class Level {
     VERBOSE,
     DEBUG,
     INFO,
@@ -13,10 +13,10 @@ interface Logger {
 
 
   /** Logs a String object using a given level.  */
-  fun log(level: LogLevel, tag: String? = null, message: String)
+  fun log(level: Level, tag: String? = null, message: String)
 
   /** Logs a String and Throwable object using a given level.  */
-  fun log(level: LogLevel, throwable: Throwable, tag: String? = null, message: String)
+  fun log(level: Level, throwable: Throwable, tag: String? = null, message: String)
 
   /** Logs a key-value pair.  */
   fun log(key: String, value: Any?)
@@ -26,77 +26,77 @@ interface Logger {
 
   /** Log a verbose message with optional format args.  */
   fun v(tag: String, message: String, vararg args: Any) {
-    this.log(LogLevel.VERBOSE, tag, message)
+    this.log(Level.VERBOSE, tag, message)
   }
 
   /** Log a verbose exception and a message with optional format args.  */
   fun v(tag: String, t: Throwable, message: String, vararg args: Any) {
-    this.log(LogLevel.VERBOSE, t, tag, message)
+    this.log(Level.VERBOSE, t, tag, message)
   }
 
   /** Log a verbose message with optional format args without tag.  */
   fun v(message: String, vararg args: Any) {
-    this.log(LogLevel.VERBOSE, null, message)
+    this.log(Level.VERBOSE, null, message)
   }
 
   /** Log a debug message with optional format args.  */
   fun d(tag: String, message: String, vararg args: Any) {
-    this.log(LogLevel.DEBUG, tag, message)
+    this.log(Level.DEBUG, tag, message)
   }
 
   /** Log a debug exception and a message with optional format args.  */
   fun d(tag: String, t: Throwable, message: String, vararg args: Any) {
-    this.log(LogLevel.DEBUG, t, tag, message)
+    this.log(Level.DEBUG, t, tag, message)
   }
 
   /** Log a debug message with optional format args.  */
   fun d(message: String, vararg args: Any) {
-    this.log(LogLevel.DEBUG, null, message)
+    this.log(Level.DEBUG, null, message)
   }
 
   /** Log an info message with optional format args.  */
   fun i(tag: String, message: String, vararg args: Any) {
-    this.log(LogLevel.INFO, tag, message)
+    this.log(Level.INFO, tag, message)
   }
 
   /** Log an info exception and a message with optional format args.  */
   fun i(tag: String, t: Throwable, message: String, vararg args: Any) {
-    this.log(LogLevel.INFO, t, tag, message)
+    this.log(Level.INFO, t, tag, message)
   }
 
   /** Log an info message with optional format args.  */
   fun i(message: String, vararg args: Any) {
-    this.log(LogLevel.INFO, null, message)
+    this.log(Level.INFO, null, message)
   }
 
   /** Log a warning message with optional format args.  */
   fun w(tag: String, message: String, vararg args: Any) {
-    this.log(LogLevel.WARNING, tag, message)
+    this.log(Level.WARNING, tag, message)
   }
 
   /** Log a warning exception and a message with optional format args.  */
   fun w(tag: String, t: Throwable, message: String, vararg args: Any) {
-    this.log(LogLevel.WARNING, t, tag, message)
+    this.log(Level.WARNING, t, tag, message)
   }
 
   /** Log a warning message with optional format args.  */
   fun w(message: String, vararg args: Any) {
-    this.log(LogLevel.WARNING, null, message)
+    this.log(Level.WARNING, null, message)
   }
 
   /** Log an error message with optional format args.  */
   fun e(tag: String, message: String, vararg args: Any) {
-    this.log(LogLevel.ERROR, tag, message)
+    this.log(Level.ERROR, tag, message)
   }
 
   /** Log an error exception and a message with optional format args.  */
   fun e(tag: String, t: Throwable, message: String, vararg args: Any) {
-    this.log(LogLevel.ERROR, t, tag, message)
+    this.log(Level.ERROR, t, tag, message)
   }
 
   /** Log an error message with optional format args.  */
   fun e(message: String, vararg args: Any) {
-    this.log(LogLevel.ERROR, null, message)
+    this.log(Level.ERROR, null, message)
   }
 
   /** Method to send issue to external servers or local files.  */

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/Logger.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/Logger.kt
@@ -3,12 +3,12 @@ package com.mobilejazz.harmony.kotlin.core.logger
 /** Logging interface.  */
 interface Logger {
 
-  enum class Level {
-    VERBOSE,
-    DEBUG,
-    INFO,
-    WARNING,
-    ERROR
+  enum class Level(val representation: String) {
+    VERBOSE("VERBOSE"),
+    DEBUG("DEBUG"),
+    INFO("INFO"),
+    WARNING("WARNING"),
+    ERROR("ERROR")
   }
 
 

--- a/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/Logger.kt
+++ b/core/src/main/java/com/mobilejazz/harmony/kotlin/core/logger/Logger.kt
@@ -1,0 +1,123 @@
+package com.mobilejazz.harmony.kotlin.core.logger
+
+/** Logging interface.  */
+interface Logger {
+
+  enum class LogLevel {
+    VERBOSE,
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR
+  }
+
+
+  /** Logs a String object using a given level.  */
+  fun log(level: LogLevel, tag: String? = null, message: String)
+
+  /** Logs a String and Throwable object using a given level.  */
+  fun log(level: LogLevel, throwable: Throwable, tag: String? = null, message: String)
+
+  /** Logs a key-value pair.  */
+  fun log(key: String, value: Any?)
+
+
+  /** DEFAULT IMPLEMENTATIONS  */
+
+  /** Log a verbose message with optional format args.  */
+  fun v(tag: String, message: String, vararg args: Any) {
+    this.log(LogLevel.VERBOSE, tag, message)
+  }
+
+  /** Log a verbose exception and a message with optional format args.  */
+  fun v(tag: String, t: Throwable, message: String, vararg args: Any) {
+    this.log(LogLevel.VERBOSE, t, tag, message)
+  }
+
+  /** Log a verbose message with optional format args without tag.  */
+  fun v(message: String, vararg args: Any) {
+    this.log(LogLevel.VERBOSE, null, message)
+  }
+
+  /** Log a debug message with optional format args.  */
+  fun d(tag: String, message: String, vararg args: Any) {
+    this.log(LogLevel.DEBUG, tag, message)
+  }
+
+  /** Log a debug exception and a message with optional format args.  */
+  fun d(tag: String, t: Throwable, message: String, vararg args: Any) {
+    this.log(LogLevel.DEBUG, t, tag, message)
+  }
+
+  /** Log a debug message with optional format args.  */
+  fun d(message: String, vararg args: Any) {
+    this.log(LogLevel.DEBUG, null, message)
+  }
+
+  /** Log an info message with optional format args.  */
+  fun i(tag: String, message: String, vararg args: Any) {
+    this.log(LogLevel.INFO, tag, message)
+  }
+
+  /** Log an info exception and a message with optional format args.  */
+  fun i(tag: String, t: Throwable, message: String, vararg args: Any) {
+    this.log(LogLevel.INFO, t, tag, message)
+  }
+
+  /** Log an info message with optional format args.  */
+  fun i(message: String, vararg args: Any) {
+    this.log(LogLevel.INFO, null, message)
+  }
+
+  /** Log a warning message with optional format args.  */
+  fun w(tag: String, message: String, vararg args: Any) {
+    this.log(LogLevel.WARNING, tag, message)
+  }
+
+  /** Log a warning exception and a message with optional format args.  */
+  fun w(tag: String, t: Throwable, message: String, vararg args: Any) {
+    this.log(LogLevel.WARNING, t, tag, message)
+  }
+
+  /** Log a warning message with optional format args.  */
+  fun w(message: String, vararg args: Any) {
+    this.log(LogLevel.WARNING, null, message)
+  }
+
+  /** Log an error message with optional format args.  */
+  fun e(tag: String, message: String, vararg args: Any) {
+    this.log(LogLevel.ERROR, tag, message)
+  }
+
+  /** Log an error exception and a message with optional format args.  */
+  fun e(tag: String, t: Throwable, message: String, vararg args: Any) {
+    this.log(LogLevel.ERROR, t, tag, message)
+  }
+
+  /** Log an error message with optional format args.  */
+  fun e(message: String, vararg args: Any) {
+    this.log(LogLevel.ERROR, null, message)
+  }
+
+  /** Method to send issue to external servers or local files.  */
+  fun sendIssue(tag: String, message: String)
+
+  /** Sets a device detail with boolean type.  */
+  fun setDeviceBoolean(key: String, value: Boolean)
+
+  /** Sets a device detail with string type.  */
+  fun setDeviceString(key: String, value: String)
+
+  /** Sets a device detail with integer type.  */
+  fun setDeviceInteger(key: String, value: Int)
+
+  /** Sets a device detail with double type.  */
+
+  fun setDeviceFloat(key: String, value: Float)
+
+  /** Remove a device detail.  */
+  fun removeDeviceKey(key: String)
+
+  /** Get the device identifier generated.  */
+  val deviceIdentifier: String
+}

--- a/sample/src/main/java/com/mobilejazz/sample/di/general/AndroidDI.kt
+++ b/sample/src/main/java/com/mobilejazz/sample/di/general/AndroidDI.kt
@@ -2,9 +2,13 @@ package com.mobilejazz.sample.di.general
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.mobilejazz.harmony.kotlin.android.logger.AndroidLogger
+import com.mobilejazz.harmony.kotlin.core.logger.ConsoleLogger
+import com.mobilejazz.harmony.kotlin.core.logger.Logger
 import dagger.Module
 import dagger.Provides
 import dagger.Subcomponent
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module(subcomponents = [(AndroidComponent::class)])
@@ -13,12 +17,28 @@ class AndroidModule {
   @Provides
   @Singleton
   fun provideSharedPreferences(c: Context): SharedPreferences = c.getSharedPreferences("items-preferences", Context.MODE_PRIVATE)
+
+  @Provides
+  @Singleton
+  @Named("ConsoleLogger")
+  fun provideConsoleLogger(): Logger = ConsoleLogger()
+
+  @Provides
+  @Singleton
+  @Named("AndroidLogger")
+  fun provideAndroidLogger(): Logger = AndroidLogger()
 }
 
 @Subcomponent
 interface AndroidComponent {
 
   fun sharedPreferences(): SharedPreferences
+
+  @Named("ConsoleLogger")
+  fun consoleLogger(): Logger
+
+  @Named("AndroidLogger")
+  fun androidLogger(): Logger
 
   @Subcomponent.Builder
   interface Builder {

--- a/sample/src/main/java/com/mobilejazz/sample/screens/home/HomeActivity.kt
+++ b/sample/src/main/java/com/mobilejazz/sample/screens/home/HomeActivity.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.mobilejazz.harmony.kotlin.android.threading.extension.onCompleteUi
 import com.mobilejazz.harmony.kotlin.core.domain.interactor.GetInteractor
+import com.mobilejazz.harmony.kotlin.core.logger.Logger
 import com.mobilejazz.harmony.kotlin.core.repository.operation.CacheSyncOperation
 import com.mobilejazz.harmony.kotlin.core.repository.operation.MainSyncOperation
 import com.mobilejazz.harmony.kotlin.core.repository.query.KeyQuery
@@ -19,6 +20,7 @@ import com.mobilejazz.sample.screens.detail.ItemDetailActivity
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_home.*
 import javax.inject.Inject
+import javax.inject.Named
 
 class HomeActivity : AppCompatActivity() {
 
@@ -33,6 +35,11 @@ class HomeActivity : AppCompatActivity() {
   @Inject
   lateinit var getAskStoriesInteractor: GetInteractor<ItemIds>
 
+  @field:[Inject Named("ConsoleLogger")]
+  lateinit var consoleLogger: Logger
+
+  @field:[Inject Named("AndroidLogger")]
+  lateinit var androidLogger: Logger
 
   override fun onCreate(savedInstanceState: Bundle?) {
     AndroidInjection.inject(this)
@@ -52,6 +59,8 @@ class HomeActivity : AppCompatActivity() {
     }
 
     reloadData(false)
+
+    printLoggers()
   }
 
   private fun reloadData(pullToRefresh: Boolean) {
@@ -77,5 +86,16 @@ class HomeActivity : AppCompatActivity() {
               Snackbar.make(activity_home_items_rv, "Error : " + it.localizedMessage, Snackbar.LENGTH_SHORT)
               Log.e("Error", it.localizedMessage)
             })
+  }
+
+  private fun printLoggers() {
+    consoleLogger.d("TAG", "HomeActivity onCreate consoleLogger")
+    androidLogger.d("TAG", "HomeActivity onCreate consoleLogger")
+
+    consoleLogger.i("HomeActivity onCreate consoleLogger NO TAG")
+    androidLogger.i("HomeActivity onCreate consoleLogger NO TAG")
+
+    consoleLogger.e("TAG", Throwable(), "HomeActivity onCreate consoleLogger Throwable")
+    androidLogger.e("TAG", Throwable(), "HomeActivity onCreate consoleLogger Throwable")
   }
 }


### PR DESCRIPTION
Kotlin Logger implementation.

Using interface default implementation since we cannot do an interface extension like Swift does. Related: https://stackoverflow.com/a/50362867 In case that we want to use Harmony's logger we need to use Kotlin implementations and replace old Java implementations.

Also, it includes a feature that allow us to log without a TAG. AndroidLogger can create tags on the fly, it uses the current class name.