### PR TITLE
WIP: Create GenericNetworkQueries

### DIFF
--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkDataSource.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkDataSource.kt
@@ -36,67 +36,6 @@ open class GetNetworkDataSource<T>(
             headers(globalHeaders)
           }
         }
-
-        /*
-
-        is OAuthClientQuery -> {
-          when (query) {
-            is OAuthPasswordPaginationOffsetLimitQuery -> {
-              httpClient.get<String>(_url) {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                paginationOffsetLimitParams(query.offset, query.limit)
-                headers(globalHeaders)
-              }
-            }
-            is OAuthPasswordIntegerIdQuery -> {
-              val url = "${_url}/${query.id}"
-              httpClient.get<String>(url) {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-            is OAuthPasswordIdQuery<*> -> {
-              val url = "${_url}/${query.identifier}"
-              httpClient.get<String>(url) {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-            is DefaultOAuthClientQuery -> {
-              httpClient.get<String>(_url) {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-            is OAuthPasswordKeyQuery -> {
-              httpClient.get<String>(_url) {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-            else -> notSupportedQuery()
-          }
-        }
-        is PaginationOffsetLimitQuery -> {
-          httpClient.get<String>(_url) {
-            paginationOffsetLimitParams(query.offset, query.limit)
-            headers(globalHeaders)
-          }
-        }
-        is IntegerIdQuery -> {
-          val url = "${_url}/${query.id}"
-          httpClient.get<String>(url) {
-            headers(globalHeaders)
-          }
-        }
-        is IdQuery<*> -> {
-          val url = "${_url}/${query.identifier}"
-          httpClient.get<String>(url) {
-            headers(globalHeaders)
-          }
-        }
-
-         */
       }
 
       return@network json.parse(serializer, response)
@@ -120,41 +59,6 @@ open class GetNetworkDataSource<T>(
         else -> {
           httpClient.get<String>(url)
         }
-
-        /*
-
-        is OAuthClientQuery -> {
-          when (query) {
-            is OAuthPasswordPaginationOffsetLimitQuery -> {
-              httpClient.get<String>(_url) {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                paginationOffsetLimitParams(query.offset, query.limit)
-                headers(globalHeaders)
-              }
-            }
-            is DefaultOAuthClientQuery -> {
-              httpClient.get<String>(_url) {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-
-            is OAuthPasswordIdQuery<*> -> {
-              httpClient.get<String>("${_url}/${query.identifier}") {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-            is OAuthPasswordKeyQuery -> {
-              httpClient.get<String>(_url) {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-            else -> notSupportedQuery()
-          }
-        }
-         */
       }
       return@network json.parse(serializer.list, response)
     }
@@ -162,7 +66,7 @@ open class GetNetworkDataSource<T>(
 
   private suspend fun HttpRequestBuilder.createHttpRequestFromGenericNetworkQuery(query: GenericNetworkQuery) {
     url(generateUrl(url = this@GetNetworkDataSource.url, path = query.path, params = query.params))
-    addOAuthorizationHeader(query)
+    addOAuthHeaderIfNeeded(query)
     headers(globalHeaders)
     headers(query.headers)
   }
@@ -193,78 +97,11 @@ open class PutNetworkDataSource<T>(
 
         is GenericObjectNetworkQuery<*> -> {
           httpClient.post<String> {
-            createHttpRequestFromGenericNetworkQuery(query, value)
+            createHttpRequestFromGenericNetworkQuery(query, query.value as T?)
           }
         }
         else -> notSupportedQuery()
       }
-      /*
-
-      is OAuthClientQuery -> {
-        when (query) {
-          is OAuthPasswordObjectQuery<*> -> {
-            query.value?.let {
-              httpClient.post<String>(_url) {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                contentType(ContentType.Application.Json)
-                headers(globalHeaders)
-                body = it
-              }
-            } ?: throw IllegalArgumentException("ObjectQuery value is null")
-          }
-          is OAuthPasswordIntegerIdQuery -> {
-            value?.let {
-              httpClient.put<String>("${_url}/${query.id}") {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                contentType(ContentType.Application.Json)
-                headers(globalHeaders)
-                body = value
-              }
-            } ?: throw IllegalArgumentException("value != null")
-          }
-          is OAuthPasswordIdQuery<*> -> {
-            value?.let {
-              httpClient.put<String>("${_url}/${query.identifier}") {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                contentType(ContentType.Application.Json)
-                headers(globalHeaders)
-                body = value
-              }
-            } ?: throw IllegalArgumentException("value != null")
-          }
-          else -> notSupportedQuery()
-        }
-      }
-      is ObjectQuery<*> -> {
-        query.value?.let {
-          httpClient.post<String>(_url) {
-            contentType(ContentType.Application.Json)
-            headers(globalHeaders)
-            body = it
-          }
-        } ?: throw IllegalArgumentException("ObjectQuery value is null")
-      }
-      is IntegerIdQuery -> {
-        value?.let {
-          httpClient.put<String>("${_url}/${query.id}") {
-            contentType(ContentType.Application.Json)
-            headers(globalHeaders)
-            body = value
-          }
-        } ?: throw IllegalArgumentException("value != null")
-      }
-      is IdQuery<*> -> {
-        value?.let {
-          httpClient.put<String>("${_url}/${query.identifier}") {
-            contentType(ContentType.Application.Json)
-            headers(globalHeaders)
-            body = value
-          }
-        } ?: throw IllegalArgumentException("value != null")
-      }
-
-       */
-
       return@network json.parse(serializer, response)
     }
   }
@@ -272,7 +109,7 @@ open class PutNetworkDataSource<T>(
   private suspend fun HttpRequestBuilder.createHttpRequestFromGenericNetworkQuery(query: GenericNetworkQuery, value: T?) {
     url(generateUrl(url = this@PutNetworkDataSource.url, path = query.path, params = query.params))
     contentType(ContentType.Application.Json)
-    addOAuthorizationHeader(query)
+    addOAuthHeaderIfNeeded(query)
     headers(globalHeaders)
     headers(query.headers)
     body = value ?: throw IllegalArgumentException("Value cannot be null")
@@ -303,48 +140,13 @@ class DeleteNetworkDataSource(
             headers(globalHeaders)
           }
         }
-
-        /*
-        is OAuthClientQuery -> {
-          when (query) {
-            is OAuthPasswordIntegerIdQuery -> {
-              httpClient.delete<Unit>("${_url}/${query.id}") {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-            is OAuthApplicationIntegerIdQuery -> {
-              httpClient.delete<Unit>("${_url}/${query.id}") {
-                oauthApplicationCredentialHeader(query.getApplicationTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-            is OAuthPasswordIdQuery<*> -> {
-              httpClient.delete<Unit>("${_url}/${query.identifier}") {
-                oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
-                headers(globalHeaders)
-              }
-            }
-          }
-        }
-        is IntegerIdQuery -> {
-          httpClient.delete<Unit>("${_url}/${query.id}") {
-            headers(globalHeaders)
-          }
-        }
-        is IdQuery<*> -> {
-          httpClient.delete<Unit>("${_url}/${query.identifier}") {
-            headers(globalHeaders)
-          }
-        }
-         */
       }
     }
   }
 
   private suspend fun HttpRequestBuilder.createHttpRequestFromGenericNetworkQuery(query: GenericNetworkQuery) {
     url(generateUrl(url = this@DeleteNetworkDataSource.url, path = query.path, params = query.params))
-    addOAuthorizationHeader(query)
+    addOAuthHeaderIfNeeded(query)
     headers(globalHeaders)
     headers(query.headers)
   }
@@ -352,7 +154,7 @@ class DeleteNetworkDataSource(
   override suspend fun deleteAll(query: Query) = throw NotImplementedError()
 }
 
-private suspend fun HttpRequestBuilder.addOAuthorizationHeader(query: Query) {
+private suspend fun HttpRequestBuilder.addOAuthHeaderIfNeeded(query: Query) {
   if (query is GenericOAuthQuery) {
     oauthPasswordHeader(getPasswordTokenInteractor = query.getPasswordTokenInteractor)
   }

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkDataSource.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkDataSource.kt
@@ -97,7 +97,7 @@ open class PutNetworkDataSource<T>(
 
         is GenericObjectNetworkQuery<*> -> {
           httpClient.post<String> {
-            createHttpRequestFromGenericNetworkQuery(query, query.value as T?)
+            createHttpRequestFromGenericNetworkQuery(query, query.value)
           }
         }
         else -> notSupportedQuery()
@@ -106,13 +106,16 @@ open class PutNetworkDataSource<T>(
     }
   }
 
-  private suspend fun HttpRequestBuilder.createHttpRequestFromGenericNetworkQuery(query: GenericNetworkQuery, value: T?) {
-    url(generateUrl(url = this@PutNetworkDataSource.url, path = query.path, params = query.params))
-    contentType(ContentType.Application.Json)
-    addOAuthHeaderIfNeeded(query)
-    headers(globalHeaders)
-    headers(query.headers)
-    body = value ?: throw IllegalArgumentException("Value cannot be null")
+  private suspend fun <V> HttpRequestBuilder.createHttpRequestFromGenericNetworkQuery(query: GenericNetworkQuery, value: V?) {
+    value?.let {
+      url(generateUrl(url = this@PutNetworkDataSource.url, path = query.path, params = query.params))
+      contentType(ContentType.Application.Json)
+      addOAuthHeaderIfNeeded(query)
+      headers(globalHeaders)
+      headers(query.mergeHeaders())
+      body = it as Any
+    } ?: throw IllegalArgumentException("Value cannot be null")
+
   }
 
   override suspend fun putAll(query: Query, value: List<T>?): List<T> = throw NotImplementedError()

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkDataSource.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkDataSource.kt
@@ -68,7 +68,7 @@ open class GetNetworkDataSource<T>(
     url(generateUrl(url = this@GetNetworkDataSource.url, path = query.path, params = query.params))
     addOAuthHeaderIfNeeded(query)
     headers(globalHeaders)
-    headers(query.headers)
+    headers(query.mergeHeaders())
   }
 }
 
@@ -151,7 +151,7 @@ class DeleteNetworkDataSource(
     url(generateUrl(url = this@DeleteNetworkDataSource.url, path = query.path, params = query.params))
     addOAuthHeaderIfNeeded(query)
     headers(globalHeaders)
-    headers(query.headers)
+    headers(query.mergeHeaders())
   }
 
   override suspend fun deleteAll(query: Query) = throw NotImplementedError()

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkQuery.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkQuery.kt
@@ -2,7 +2,6 @@ package com.harmony.kotlin.data.datasource.network
 
 import com.harmony.kotlin.data.query.*
 import com.harmony.kotlin.library.oauth.domain.interactor.GetApplicationTokenInteractor
-import com.harmony.kotlin.library.oauth.domain.interactor.GetDefaultPasswordTokenInteractor
 import com.harmony.kotlin.library.oauth.domain.interactor.GetPasswordTokenInteractor
 
 interface OAuthClientQuery
@@ -31,49 +30,47 @@ GetPasswordTokenInteractor) : PaginationOffsetLimitQuery(identifier ?: "$offset-
 class OAuthPasswordObjectQuery<T>(value: T, val getPasswordTokenInteractor: GetPasswordTokenInteractor) : ObjectQuery<T>(value),
     OAuthClientQuery
 
-abstract class GenericNetworkQuery(
-    val path: String,
-    val params: List<Pair<String, String>>?,
-    val headers: List<Pair<String, String>>?,
-    cacheKey: String? = null) : KeyQuery(cacheKey ?: path)
 
-abstract class GenericOAuthNetworkQuery(
-    val getPasswordTokenInteractor: GetPasswordTokenInteractor,
-    path: String,
-    params: List<Pair<String, String>>? = emptyList(),
-    headers: List<Pair<String, String>>? = emptyList(),
-    cacheKey: String? = null) : GenericNetworkQuery(path, params, headers, cacheKey)
+interface GenericOAuthQuery {
+  val getPasswordTokenInteractor: GetPasswordTokenInteractor
+}
+
+open class GenericNetworkQuery(
+    val path: String,
+    val params: List<Pair<String, String>>? = emptyList(),
+    val headers: List<Pair<String, String>>? = emptyList(),
+    key: String? = null) : KeyQuery(key ?: path)
 
 // PUT Create JavaDoc
-abstract class GenericIdNetworkQuery(
-    val id: Int,
+open class GenericIdNetworkQuery<T>(
+    val id: T,
     path: String,
     params: List<Pair<String, String>>? = emptyList(),
     headers: List<Pair<String, String>>? = emptyList(),
-    cacheKey: String? = null) : GenericNetworkQuery(path, params, headers, cacheKey)
+    key: String? = null) : GenericNetworkQuery(path, params, headers, key)
 
-abstract class GenericOAuthIdNetworkQuery(
-    val id: Int,
-    getPasswordTokenInteractor: GetPasswordTokenInteractor,
+class GenericOAuthIdNetworkQuery<T>(
+    id: T,
     path: String,
     params: List<Pair<String, String>>? = emptyList(),
     headers: List<Pair<String, String>>? = emptyList(),
-    cacheKey: String? = null) : GenericOAuthNetworkQuery(getPasswordTokenInteractor, path, params, headers, cacheKey)
+    key: String? = null,
+    override val getPasswordTokenInteractor: GetPasswordTokenInteractor) : GenericIdNetworkQuery<T>(id, path, params, headers, key), GenericOAuthQuery
 
 // POST Create JavaDoc
-abstract class GenericObjectNetworkQuery<T>(
+open class GenericObjectNetworkQuery<T>(
     val value: T,
     path: String,
     params: List<Pair<String, String>>? = emptyList(),
     headers: List<Pair<String, String>>? = emptyList(),
-    cacheKey: String? = null) : GenericNetworkQuery(path, params, headers, cacheKey)
+    key: String? = null) : GenericNetworkQuery(path, params, headers, key)
 
-abstract class GenericOAuthObjectNetworkQuery<T>(
-    val value: T,
-    getPasswordTokenInteractor: GetPasswordTokenInteractor,
+class GenericOAuthObjectNetworkQuery<T>(
+    value: T,
     path: String,
     params: List<Pair<String, String>>? = emptyList(),
     headers: List<Pair<String, String>>? = emptyList(),
-    cacheKey: String? = null) : GenericOAuthNetworkQuery(getPasswordTokenInteractor, path, params, headers, cacheKey)
+    key: String? = null,
+    override val getPasswordTokenInteractor: GetPasswordTokenInteractor) : GenericObjectNetworkQuery<T>(value, path, params, headers, key), GenericOAuthQuery
 
 

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkQuery.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkQuery.kt
@@ -30,46 +30,56 @@ GetPasswordTokenInteractor) : PaginationOffsetLimitQuery(identifier ?: "$offset-
 class OAuthPasswordObjectQuery<T>(value: T, val getPasswordTokenInteractor: GetPasswordTokenInteractor) : ObjectQuery<T>(value),
     OAuthClientQuery
 
-
+/**
+ * Implement the interface and override getPasswordTokenInteractor when you need oAuth authorization.
+ */
 interface GenericOAuthQuery {
   val getPasswordTokenInteractor: GetPasswordTokenInteractor
 }
 
+/**
+ * Base class.
+ * In case you want to customize the cache key, provide a key string.
+ */
 open class GenericNetworkQuery(
     val path: String,
-    val params: List<Pair<String, String>>? = emptyList(),
-    val headers: List<Pair<String, String>>? = emptyList(),
+    val params: List<Pair<String, String>> = emptyList(),
+    val headers: List<Pair<String, String>> = emptyList(),
     key: String? = null) : KeyQuery(key ?: path)
 
-// PUT Create JavaDoc
+/**
+ * Creates a PUT Http Method. Modifies the ID with the value that receive the put method.
+ */
 open class GenericIdNetworkQuery<T>(
     val id: T,
     path: String,
-    params: List<Pair<String, String>>? = emptyList(),
-    headers: List<Pair<String, String>>? = emptyList(),
+    params: List<Pair<String, String>> = emptyList(),
+    headers: List<Pair<String, String>> = emptyList(),
     key: String? = null) : GenericNetworkQuery(path, params, headers, key)
 
 class GenericOAuthIdNetworkQuery<T>(
     id: T,
     path: String,
-    params: List<Pair<String, String>>? = emptyList(),
-    headers: List<Pair<String, String>>? = emptyList(),
+    params: List<Pair<String, String>> = emptyList(),
+    headers: List<Pair<String, String>> = emptyList(),
     key: String? = null,
     override val getPasswordTokenInteractor: GetPasswordTokenInteractor) : GenericIdNetworkQuery<T>(id, path, params, headers, key), GenericOAuthQuery
 
-// POST Create JavaDoc
+/**
+ * Creates a POST Http Method. Creates a new entry with the value in the query object.
+ */
 open class GenericObjectNetworkQuery<T>(
     val value: T,
     path: String,
-    params: List<Pair<String, String>>? = emptyList(),
-    headers: List<Pair<String, String>>? = emptyList(),
+    params: List<Pair<String, String>> = emptyList(),
+    headers: List<Pair<String, String>> = emptyList(),
     key: String? = null) : GenericNetworkQuery(path, params, headers, key)
 
 class GenericOAuthObjectNetworkQuery<T>(
     value: T,
     path: String,
-    params: List<Pair<String, String>>? = emptyList(),
-    headers: List<Pair<String, String>>? = emptyList(),
+    params: List<Pair<String, String>> = emptyList(),
+    headers: List<Pair<String, String>> = emptyList(),
     key: String? = null,
     override val getPasswordTokenInteractor: GetPasswordTokenInteractor) : GenericObjectNetworkQuery<T>(value, path, params, headers, key), GenericOAuthQuery
 

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkQuery.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkQuery.kt
@@ -31,3 +31,49 @@ GetPasswordTokenInteractor) : PaginationOffsetLimitQuery(identifier ?: "$offset-
 class OAuthPasswordObjectQuery<T>(value: T, val getPasswordTokenInteractor: GetPasswordTokenInteractor) : ObjectQuery<T>(value),
     OAuthClientQuery
 
+abstract class GenericNetworkQuery(
+    val path: String,
+    val params: List<Pair<String, String>>?,
+    val headers: List<Pair<String, String>>?,
+    cacheKey: String? = null) : KeyQuery(cacheKey ?: path)
+
+abstract class GenericOAuthNetworkQuery(
+    val getPasswordTokenInteractor: GetPasswordTokenInteractor,
+    path: String,
+    params: List<Pair<String, String>>? = emptyList(),
+    headers: List<Pair<String, String>>? = emptyList(),
+    cacheKey: String? = null) : GenericNetworkQuery(path, params, headers, cacheKey)
+
+// PUT Create JavaDoc
+abstract class GenericIdNetworkQuery(
+    val id: Int,
+    path: String,
+    params: List<Pair<String, String>>? = emptyList(),
+    headers: List<Pair<String, String>>? = emptyList(),
+    cacheKey: String? = null) : GenericNetworkQuery(path, params, headers, cacheKey)
+
+abstract class GenericOAuthIdNetworkQuery(
+    val id: Int,
+    getPasswordTokenInteractor: GetPasswordTokenInteractor,
+    path: String,
+    params: List<Pair<String, String>>? = emptyList(),
+    headers: List<Pair<String, String>>? = emptyList(),
+    cacheKey: String? = null) : GenericOAuthNetworkQuery(getPasswordTokenInteractor, path, params, headers, cacheKey)
+
+// POST Create JavaDoc
+abstract class GenericObjectNetworkQuery<T>(
+    val value: T,
+    path: String,
+    params: List<Pair<String, String>>? = emptyList(),
+    headers: List<Pair<String, String>>? = emptyList(),
+    cacheKey: String? = null) : GenericNetworkQuery(path, params, headers, cacheKey)
+
+abstract class GenericOAuthObjectNetworkQuery<T>(
+    val value: T,
+    getPasswordTokenInteractor: GetPasswordTokenInteractor,
+    path: String,
+    params: List<Pair<String, String>>? = emptyList(),
+    headers: List<Pair<String, String>>? = emptyList(),
+    cacheKey: String? = null) : GenericOAuthNetworkQuery(getPasswordTokenInteractor, path, params, headers, cacheKey)
+
+

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkQuery.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkQuery.kt
@@ -45,7 +45,24 @@ open class GenericNetworkQuery(
     val path: String,
     val params: List<Pair<String, String>> = emptyList(),
     val headers: List<Pair<String, String>> = emptyList(),
-    key: String? = null) : KeyQuery(key ?: path)
+    key: String? = null) : KeyQuery(
+    key ?: generateNetworkQueryKey(path, params))
+
+/**
+ * Generates a key following the same pattern as a GET url.
+ *
+ * E.g: path?key1=value1&key2=value2
+ */
+private fun generateNetworkQueryKey(path: String, params: List<Pair<String, String>>): String {
+  return path +
+      if (params.isEmpty()) {
+        ""
+      } else {
+        "?" + params.joinToString(separator = "&") {
+          it.first + "=" + it.second
+        }
+      }
+}
 
 /**
  * Creates a PUT Http Method. Modifies the ID with the value that receive the put method.

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/UrlExtensions.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/UrlExtensions.kt
@@ -1,0 +1,25 @@
+package com.harmony.kotlin.data.datasource.network
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.ParametersBuilder
+import io.ktor.http.URLBuilder
+
+fun HttpRequestBuilder.generateUrl(url: String, path: String, params: List<Pair<String, String>>?): String {
+
+  val urlBuilder = URLBuilder("$url/$path")
+  params?.also { params ->
+    urlBuilder.parameters.also {
+      it.appendAll(generateParams(params).build())
+    }
+  }
+  return urlBuilder.buildString()
+
+}
+
+private fun generateParams(params: List<Pair<String, String>>): ParametersBuilder {
+  val parametersBuilder = ParametersBuilder(params.size)
+  params.forEach {
+    parametersBuilder.append(it.first, it.second)
+  }
+  return parametersBuilder
+}

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/UrlExtensions.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/UrlExtensions.kt
@@ -1,17 +1,18 @@
 package com.harmony.kotlin.data.datasource.network
 
-import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.http.ParametersBuilder
 import io.ktor.http.URLBuilder
 
-fun HttpRequestBuilder.generateUrl(url: String, path: String, params: List<Pair<String, String>>?): String {
+fun generateUrl(url: String, path: String, params: List<Pair<String, String>> = emptyList()): String {
 
   val urlBuilder = URLBuilder("$url/$path")
-  params?.also { params ->
+
+  if (params.isNotEmpty()) {
     urlBuilder.parameters.also {
       it.appendAll(generateParams(params).build())
     }
   }
+
   return urlBuilder.buildString()
 
 }


### PR DESCRIPTION
**GenericNetworkQueries.**

It is a very basic implementation of GenericNetworkQueries. We can generate dynamic URLs and use GenericNetworkDataSource.

I leave the old implementations because I think it's easier to see the PR but we will remove once we got a stable version.

DONE:

- [x] Create a basic implementation for each kind of query
- [x] Implementation each query for each CRUD method
- [x] Headers. This version misses the custom header. We need to call the current method headers() with query.headers if they exist.
- [x] Javadoc

IN PROGRESS:


TO BE DONE or SUGGESTIONS:


- [x] I would like to improve how we create the request. I see them as a builder pattern. All of them are generic queries that we can customize/build. So for example, I would like to do something like httpclient.get.url.headers.oauth. Thanks to this it's easier to build the query and we avoid the current duplicate code. BUT I don't know how to do it.