### PR TITLE
Add try-catch helper functions

### DIFF
--- a/common/src/commonMain/kotlin/com.harmony.kotlin/common/exceptions/TryCatchHelpers.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/common/exceptions/TryCatchHelpers.kt
@@ -1,0 +1,46 @@
+package com.harmony.kotlin.common.exceptions
+
+import com.harmony.kotlin.common.logger.Logger
+
+/**
+ * Try this block and re-throw any Exception while logging it.
+ */
+inline fun <R> tryOrThrow(logger: Logger, tag: String, message: String = "Exception logged", level: Logger.Level = Logger.Level
+    .WARNING, block: () -> R):
+    R {
+  return try {
+    block()
+  } catch (e: Exception) {
+    logger.log(level, e, tag, message)
+    throw e
+  }
+}
+
+/**
+ * Try this block and catch any Exception.
+ *
+ * Optionally a logger and some parameters can be passed to log the Exception
+ */
+inline fun <R> tryOrCatch(logger: Logger? = null, tag: String = "TryOrCatch", message: String = "Exception logged", level: Logger.Level = Logger.Level.WARNING, block: () -> R) {
+  return try {
+    block()
+    Unit
+  } catch (e: Exception) {
+    logger?.log(level, e, tag, message)
+    Unit
+  }
+}
+
+/**
+ * Try this block and return null if there is any Exception.
+ *
+ * Optionally a logger and some parameters can be passed to log the Exception
+ */
+inline fun <R> tryOrNull(logger: Logger? = null, tag: String = "TryOrNull", message: String = "Exception logged", level: Logger.Level = Logger.Level.WARNING, block: () -> R): R? {
+  return try {
+    block()
+  } catch (e: Exception) {
+    logger?.log(level, e, tag, message)
+    null
+  }
+}


### PR DESCRIPTION
I needed to log some exceptions and finally came up with those helper functions:

 - tryOrThrow: Intended for just logging the exception without interfering with it
 - tryOrCatch: Intended for ignoring any Exception, logging is optional.
 - tryOrNull: Return null if there is any exception (same behavior of the Swift equivalent), logging is optional.

Some usage samples:
`  tryOrThrow(logger, "tag") {
    <exeptions inside will be logged and re-thrown>
  }`
 ` tryOrCatch {
    <exeptions inside will be ignored >
  }`
 ` tryOrCatch(logger) {
    <exeptions inside will be ignored and logged >
  }`
` val nullableResult = tryOrNull {
    <exeptions inside will be captured and null will be returned>
  }`
` val nullableResult = tryOrNull(logger, "tag") {
    <exeptions inside will be captured, logged and null will be returned>
  }`

This PR is intended to be merged in branch kotlin-multiplatform-threading.