### PR TITLE
Add Mapping/Serialization Exception

### DIFF
--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/error/Error.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/error/Error.kt
@@ -1,6 +1,9 @@
 package com.harmony.kotlin.data.error
 
 // Errors
+/**
+ * Generic exception for errors on the data layer
+ */
 open class RepositoryException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
 
 open class DataNotFoundException(message: String? = "Data not found", cause: Throwable? = null) : RepositoryException(message, cause)
@@ -13,8 +16,17 @@ class ObjectNotValidException(message: String? = "Object not valid", cause: Thro
 
 class QueryNotSupportedException(message: String? = "Query not supported", cause: Throwable? = null) : RepositoryException(message, cause)
 
+/**
+ * Exception for errors on the mappers
+ */
 open class MappingException(message: String? = "Exception thrown during mapping", cause: Throwable? = null) : RepositoryException(message, cause)
 
-class SerializationException(message: String? = "Exception thrown during serialization", cause: Throwable? = null) : MappingException(message, cause)
+/**
+ * Exception for serialization errors on the mappers
+ */
+class MappingSerializationException(message: String? = "Exception thrown during serialization", cause: Throwable? = null) : MappingException(message, cause)
 
+/**
+ * Exception for network errors
+ */
 open class NetworkErrorException(val statusCode: Int, message: String?, throwable: Throwable? = null) : RepositoryException(message, throwable)

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/error/Error.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/error/Error.kt
@@ -2,7 +2,7 @@ package com.harmony.kotlin.data.error
 
 // Errors
 
-open class RepositoryException(message: String? = null, cause: Throwable? = null) : Exception(message)
+open class RepositoryException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
 
 open class DataNotFoundException(message: String? = "Data not found", cause: Throwable? = null) : RepositoryException(message, cause)
 
@@ -12,4 +12,8 @@ class PutObjectFailException(message: String? = "Fail updating or inserting obje
 
 class ObjectNotValidException(message: String? = "Object not valid", cause: Throwable? = null) : RepositoryException(message, cause)
 
-class QueryNotSupportedException(message: String? = "Query not supported", cause: Throwable? = null): RepositoryException(message, cause)
+class QueryNotSupportedException(message: String? = "Query not supported", cause: Throwable? = null) : RepositoryException(message, cause)
+
+open class MappingException(message: String? = "Exception thrown during mapping", cause: Throwable? = null) : Exception(message, cause)
+
+open class SerializationException(message: String? = "Exception thrown during serialization", cause: Throwable? = null) : MappingException(message, cause)

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/error/Error.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/error/Error.kt
@@ -1,7 +1,6 @@
 package com.harmony.kotlin.data.error
 
 // Errors
-
 open class RepositoryException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
 
 open class DataNotFoundException(message: String? = "Data not found", cause: Throwable? = null) : RepositoryException(message, cause)
@@ -14,6 +13,8 @@ class ObjectNotValidException(message: String? = "Object not valid", cause: Thro
 
 class QueryNotSupportedException(message: String? = "Query not supported", cause: Throwable? = null) : RepositoryException(message, cause)
 
-open class MappingException(message: String? = "Exception thrown during mapping", cause: Throwable? = null) : Exception(message, cause)
+open class MappingException(message: String? = "Exception thrown during mapping", cause: Throwable? = null) : RepositoryException(message, cause)
 
-open class SerializationException(message: String? = "Exception thrown during serialization", cause: Throwable? = null) : MappingException(message, cause)
+class SerializationException(message: String? = "Exception thrown during serialization", cause: Throwable? = null) : MappingException(message, cause)
+
+open class NetworkErrorException(val statusCode: Int, message: String?, throwable: Throwable? = null) : RepositoryException(message, throwable)

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/error/NetworkErrorException.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/error/NetworkErrorException.kt
@@ -1,4 +1,0 @@
-package com.harmony.kotlin.data.error
-
-open class NetworkErrorException(val statusCode: Int, message: String?, throwable: Throwable? = null) :
-    RuntimeException(message, throwable)

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/mapper/CBORObjectToByteArray.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/mapper/CBORObjectToByteArray.kt
@@ -1,6 +1,6 @@
 package com.harmony.kotlin.data.mapper
 
-import com.harmony.kotlin.data.error.SerializationException
+import com.harmony.kotlin.data.error.MappingSerializationException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.list
 import kotlinx.serialization.cbor.*
@@ -9,7 +9,7 @@ class CBORObjectToByteArray<T>(private val cbor: Cbor, private val serializer: K
   override fun map(from: T): ByteArray = try {
     cbor.dump(serializer, from)
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 
@@ -17,7 +17,7 @@ class CBORListObjectToByteArray<T>(private val cbor: Cbor, private val serialize
   override fun map(from: List<T>): ByteArray = try {
     cbor.dump(serializer.list, from)
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 
@@ -25,7 +25,7 @@ class CBORByteArrayToObject<T>(private val cbor: Cbor, private val serializer: K
   override fun map(from: ByteArray): T = try {
     cbor.load(serializer, from)
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 
@@ -34,7 +34,7 @@ class CBORByteArrayToListObject<T>(private val cbor: Cbor, private val serialize
   override fun map(from: ByteArray): List<T> = try {
     cbor.load(serializer.list, from)
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/mapper/CBORObjectToByteArray.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/mapper/CBORObjectToByteArray.kt
@@ -1,23 +1,41 @@
 package com.harmony.kotlin.data.mapper
 
+import com.harmony.kotlin.data.error.SerializationException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.list
 import kotlinx.serialization.cbor.*
 
-class CBORObjectToByteArray<T>(private val cbor: Cbor, private val serializer: KSerializer<T>): Mapper<T, ByteArray> {
-    override fun map(from: T): ByteArray = cbor.dump(serializer, from)
+class CBORObjectToByteArray<T>(private val cbor: Cbor, private val serializer: KSerializer<T>) : Mapper<T, ByteArray> {
+  override fun map(from: T): ByteArray = try {
+    cbor.dump(serializer, from)
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }
 
-class CBORListObjectToByteArray<T>(private val cbor: Cbor, private val serializer: KSerializer<T>): Mapper<List<T>, ByteArray> {
-    override fun map(from: List<T>): ByteArray = cbor.dump(serializer.list, from)
+class CBORListObjectToByteArray<T>(private val cbor: Cbor, private val serializer: KSerializer<T>) : Mapper<List<T>, ByteArray> {
+  override fun map(from: List<T>): ByteArray = try {
+    cbor.dump(serializer.list, from)
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }
 
-class CBORByteArrayToObject<T>(private val cbor: Cbor, private val serializer: KSerializer<T>): Mapper<ByteArray, T> {
-    override fun map(from: ByteArray): T = cbor.load(serializer, from)
+class CBORByteArrayToObject<T>(private val cbor: Cbor, private val serializer: KSerializer<T>) : Mapper<ByteArray, T> {
+  override fun map(from: ByteArray): T = try {
+    cbor.load(serializer, from)
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }
 
-class CBORByteArrayToListObject<T>(private val cbor: Cbor, private val serializer: KSerializer<T>): Mapper<ByteArray, List<T>> {
-    override fun map(from: ByteArray): List<T> = cbor.load(serializer.list, from)
+class CBORByteArrayToListObject<T>(private val cbor: Cbor, private val serializer: KSerializer<T>) : Mapper<ByteArray, List<T>> {
+
+  override fun map(from: ByteArray): List<T> = try {
+    cbor.load(serializer.list, from)
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }
 
 

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/operation/Operation.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/operation/Operation.kt
@@ -22,7 +22,7 @@ object MainSyncOperation : Operation()
 object CacheOperation : Operation()
 
 /**
- * Data stream will use the cache data source and sync with the main data source
+ * Data stream will use the cache data source and if fails it will sync with the main data source
  * @param fallback function that receives a Throwable and return a boolean flag indicating if we should fallback to cache without validating the object
  */
 class CacheSyncOperation(val fallback: (throwable: Throwable) -> Boolean = { false }) : Operation()

--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
@@ -4,6 +4,7 @@ import com.harmony.kotlin.data.datasource.DeleteDataSource
 import com.harmony.kotlin.data.datasource.GetDataSource
 import com.harmony.kotlin.data.datasource.PutDataSource
 import com.harmony.kotlin.data.error.DataNotFoundException
+import com.harmony.kotlin.data.error.MappingException
 import com.harmony.kotlin.data.error.ObjectNotValidException
 import com.harmony.kotlin.data.operation.*
 import com.harmony.kotlin.data.query.Query
@@ -48,6 +49,7 @@ class CacheRepository<V>(
           try {
             when (cacheException) {
               is ObjectNotValidException,
+              is MappingException,
               is DataNotFoundException -> get(query, MainSyncOperation)
               else -> throw cacheException
             }
@@ -91,6 +93,7 @@ class CacheRepository<V>(
           try {
             when (cacheException) {
               is ObjectNotValidException,
+              is MappingException,
               is DataNotFoundException -> getAll(query, MainSyncOperation)
               else -> throw cacheException
             }

--- a/common/src/jvmMain/kotlin/com/harmony/kotlin/data/mapper/ByteArrayMapper.kt
+++ b/common/src/jvmMain/kotlin/com/harmony/kotlin/data/mapper/ByteArrayMapper.kt
@@ -1,27 +1,39 @@
 package com.harmony.kotlin.data.mapper
 
+import com.harmony.kotlin.data.error.SerializationException
 import java.io.*
 
 /**
  * Map a byte array to a class object
  */
 class ByteArrayToModelMapper<out T : Serializable> : Mapper<ByteArray, T> {
-  override fun map(from: ByteArray): T = from.toObject()
+  override fun map(from: ByteArray): T = try {
+    from.toObject()
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }
 
 /**
  * Map a class object to a byte array
  */
 class ModelToByteArrayMapper<in T : Serializable> : Mapper<T, ByteArray> {
-  override fun map(from: T): ByteArray = from.toByteArray()
+  override fun map(from: T): ByteArray = try {
+    from.toByteArray()
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }
+
 
 /**
  * Map a byte array to a list class object
  */
 class ByteArrayToListModelMapper<out T : Serializable> : Mapper<ByteArray, List<T>> {
-  override fun map(from: ByteArray): List<T> {
-    return from.toObject()
+  override fun map(from: ByteArray): List<T> = try {
+    from.toObject()
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
   }
 }
 
@@ -29,7 +41,11 @@ class ByteArrayToListModelMapper<out T : Serializable> : Mapper<ByteArray, List<
  * Map a list class object to a byte array
  */
 class ListModelToByteArrayMapper<in T : Serializable> : Mapper<List<T>, ByteArray> {
-  override fun map(from: List<T>): ByteArray = from.toByteArray()
+  override fun map(from: List<T>): ByteArray = try {
+    from.toByteArray()
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }
 
 private fun Collection<Serializable>.toByteArray(): ByteArray {

--- a/common/src/jvmMain/kotlin/com/harmony/kotlin/data/mapper/ByteArrayMapper.kt
+++ b/common/src/jvmMain/kotlin/com/harmony/kotlin/data/mapper/ByteArrayMapper.kt
@@ -1,6 +1,6 @@
 package com.harmony.kotlin.data.mapper
 
-import com.harmony.kotlin.data.error.SerializationException
+import com.harmony.kotlin.data.error.MappingSerializationException
 import java.io.*
 
 /**
@@ -10,7 +10,7 @@ class ByteArrayToModelMapper<out T : Serializable> : Mapper<ByteArray, T> {
   override fun map(from: ByteArray): T = try {
     from.toObject()
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 
@@ -21,7 +21,7 @@ class ModelToByteArrayMapper<in T : Serializable> : Mapper<T, ByteArray> {
   override fun map(from: T): ByteArray = try {
     from.toByteArray()
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 
@@ -33,7 +33,7 @@ class ByteArrayToListModelMapper<out T : Serializable> : Mapper<ByteArray, List<
   override fun map(from: ByteArray): List<T> = try {
     from.toObject()
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 
@@ -44,7 +44,7 @@ class ListModelToByteArrayMapper<in T : Serializable> : Mapper<List<T>, ByteArra
   override fun map(from: List<T>): ByteArray = try {
     from.toByteArray()
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 

--- a/common/src/jvmMain/kotlin/com/harmony/kotlin/data/mapper/GsonMapper.kt
+++ b/common/src/jvmMain/kotlin/com/harmony/kotlin/data/mapper/GsonMapper.kt
@@ -2,27 +2,38 @@ package com.harmony.kotlin.data.mapper
 
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.harmony.kotlin.data.error.SerializationException
 
 /**
  * Map a json string to a class object
  */
 class StringToModelMapper<out T>(private val clz: Class<T>, private val gson: Gson) : Mapper<String, T> {
-  override fun map(from: String): T = gson.fromJson(from, clz)
+  override fun map(from: String): T = try {
+    gson.fromJson(from, clz)
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }
 
 /**
  * Map a class object to a json string
  */
 class ModelToStringMapper<in T>(private val gson: Gson) : Mapper<T, String> {
-  override fun map(from: T): String = gson.toJson(from)
+  override fun map(from: T): String = try {
+    gson.toJson(from)
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }
 
 /**
  * Map a list json string to a list class object
  */
 class StringToListModelMapper<out T>(private val clz: TypeToken<List<T>>, private val gson: Gson) : Mapper<String, List<T>> {
-  override fun map(from: String): List<T> {
-    return gson.fromJson(from, clz.type)
+  override fun map(from: String): List<T> = try {
+    gson.fromJson(from, clz.type)
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
   }
 }
 
@@ -30,5 +41,9 @@ class StringToListModelMapper<out T>(private val clz: TypeToken<List<T>>, privat
  * Map a list class object to a json string
  */
 class ListModelToStringMapper<in T>(private val gson: Gson) : Mapper<List<T>, String> {
-  override fun map(from: List<T>): String = gson.toJson(from)
+  override fun map(from: List<T>): String = try {
+    gson.toJson(from)
+  } catch (e: Exception) {
+    throw SerializationException(cause = e)
+  }
 }

--- a/common/src/jvmMain/kotlin/com/harmony/kotlin/data/mapper/GsonMapper.kt
+++ b/common/src/jvmMain/kotlin/com/harmony/kotlin/data/mapper/GsonMapper.kt
@@ -2,7 +2,7 @@ package com.harmony.kotlin.data.mapper
 
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import com.harmony.kotlin.data.error.SerializationException
+import com.harmony.kotlin.data.error.MappingSerializationException
 
 /**
  * Map a json string to a class object
@@ -11,7 +11,7 @@ class StringToModelMapper<out T>(private val clz: Class<T>, private val gson: Gs
   override fun map(from: String): T = try {
     gson.fromJson(from, clz)
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 
@@ -22,7 +22,7 @@ class ModelToStringMapper<in T>(private val gson: Gson) : Mapper<T, String> {
   override fun map(from: T): String = try {
     gson.toJson(from)
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 
@@ -33,7 +33,7 @@ class StringToListModelMapper<out T>(private val clz: TypeToken<List<T>>, privat
   override fun map(from: String): List<T> = try {
     gson.fromJson(from, clz.type)
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }
 
@@ -44,6 +44,6 @@ class ListModelToStringMapper<in T>(private val gson: Gson) : Mapper<List<T>, St
   override fun map(from: List<T>): String = try {
     gson.toJson(from)
   } catch (e: Exception) {
-    throw SerializationException(cause = e)
+    throw MappingSerializationException(cause = e)
   }
 }


### PR DESCRIPTION
 - Mapping is the base exception for any mapping issue.
 - Serialization should be used for the mappers that Serialize objects
 - CacheRepository automatically refresh now the cache if a MappingException is thrown