### PR TITLE
Add fallback lambda to CacheOperation to indicate when to retry from …

### DIFF
--- a/common/src/commonMain/kotlin/com.harmony.kotlin/data/operation/Operation.kt
+++ b/common/src/commonMain/kotlin/com.harmony.kotlin/data/operation/Operation.kt
@@ -18,12 +18,13 @@ object MainSyncOperation : Operation()
 
 /**
  * Data stream will only use the cache data source
+ * @param fallback function that receives a Throwable and return a boolean flag indicating if we should fallback to cache without validating the object
  */
-object CacheOperation : Operation()
+class CacheOperation(val fallback: (cacheOperationThrowable: Throwable) -> Boolean = { false }) : Operation()
 
 /**
  * Data stream will use the cache data source and if fails it will sync with the main data source
  * @param fallback function that receives a Throwable and return a boolean flag indicating if we should fallback to cache without validating the object
  */
-class CacheSyncOperation(val fallback: (throwable: Throwable) -> Boolean = { false }) : Operation()
+class CacheSyncOperation(val fallback: (mainOperationThrowable: Throwable) -> Boolean = { false }) : Operation()
 


### PR DESCRIPTION
…cache after an error

 - This should be used to recover from ObjectNotValidException if we want to ignore validation

This solves #42 