### PR TITLE
Rework CacheSyncOperation in CacheRepository

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,6 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=true
+
+# fixing issue with not be able to load the project within Intellij IDEA because an issue with Android Studio
+android.injected.studio.version.check=false

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/operation/Operation.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/operation/Operation.kt
@@ -26,4 +26,9 @@ class CacheOperation(val fallback: (cacheOperationThrowable: Throwable) -> Boole
  * Data stream will use the cache data source and if fails it will sync with the main data source
  * @param fallback function that receives a Throwable and return a boolean flag indicating if we should fallback to cache without validating the object
  */
-class CacheSyncOperation(val fallback: (mainOperationThrowable: Throwable) -> Boolean = { false }) : Operation()
+class CacheSyncOperation(
+  val fallback: (
+    mainThrowable: Throwable,
+    cacheThrowable: Throwable
+  ) -> Boolean = { _, _ -> false }
+) : Operation()

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
@@ -50,7 +50,6 @@ class CacheRepository<V>(
         putCache.put(query, it)
       }
       is CacheSyncOperation -> {
-        // Try cache
         try {
           return getCache.get(query).let {
             if (!validator.isValid(it)) {
@@ -60,7 +59,6 @@ class CacheRepository<V>(
             }
           }
         } catch (cacheException: Exception) {
-          // If cache fails, try main data source
           try {
             when (cacheException) {
               is ObjectNotValidException,
@@ -105,7 +103,6 @@ class CacheRepository<V>(
 
       is MainSyncOperation -> getMain.getAll(query).let { putCache.putAll(query, it) }
       is CacheSyncOperation -> {
-        // Try cache
         try {
           return getCache.getAll(query).map {
             if (!validator.isValid(it)) {
@@ -115,7 +112,6 @@ class CacheRepository<V>(
             }
           }
         } catch (cacheException: Exception) {
-          // If cache fails, try main data source
           try {
             when (cacheException) {
               is ObjectNotValidException,

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
@@ -1,5 +1,6 @@
 package com.harmony.kotlin.data.repository
 
+import com.harmony.core.db.Cache
 import com.harmony.kotlin.data.datasource.DeleteDataSource
 import com.harmony.kotlin.data.datasource.GetDataSource
 import com.harmony.kotlin.data.datasource.PutDataSource
@@ -30,16 +31,17 @@ class CacheRepository<V>(
     return when (operation) {
       is DefaultOperation -> get(query, CacheSyncOperation())
       is MainOperation -> getMain.get(query)
-      is CacheOperation -> getCache.get(query).let {
-        try {
-          if (!validator.isValid(it)) {
+      is CacheOperation -> {
+        val cacheValue = getCache.get(query)
+        return try {
+          if (!validator.isValid(cacheValue)) {
             throw ObjectNotValidException()
           } else {
-            it
+            cacheValue
           }
         } catch (cacheException: Exception) {
           if (operation.fallback(cacheException)) {
-            getCache.get(query)
+            cacheValue
           } else {
             throw cacheException
           }
@@ -85,21 +87,24 @@ class CacheRepository<V>(
     return when (operation) {
       is DefaultOperation -> getAll(query, CacheSyncOperation())
       is MainOperation -> getMain.getAll(query)
-      is CacheOperation -> getCache.getAll(query).map {
-        try {
-          if (!validator.isValid(it)) {
+      is CacheOperation -> {
+        val cacheValues = getCache.getAll(query)
+        return try {
+          val invalids = cacheValues.map { validator.isValid(it) }.filter { isValid -> !isValid }
+          if (invalids.isNotEmpty()) {
             throw ObjectNotValidException()
           } else {
-            it
+            cacheValues
           }
         } catch (cacheException: Exception) {
           if (operation.fallback(cacheException)) {
-            getCache.get(query)
+            cacheValues
           } else {
             throw cacheException
           }
         }
       }
+
       is MainSyncOperation -> getMain.getAll(query).let { putCache.putAll(query, it) }
       is CacheSyncOperation -> {
         // Try cache

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
@@ -69,8 +69,7 @@ class CacheRepository<V>(
               else -> throw cacheException
             }
           } catch (mainException: Exception) {
-            // If main data source fails but operation.fallback == true then try again cache without checking validity
-            if (operation.fallback(mainException) && cacheException is ObjectNotValidException) {
+            if (operation.fallback(mainException, cacheException)) {
               getCache.get(query)
             } else {
               throw mainException
@@ -125,8 +124,7 @@ class CacheRepository<V>(
               else -> throw cacheException
             }
           } catch (mainException: Exception) {
-            // If main data source fails but operation.fallback == true then try again cache without checking validity
-            if (operation.fallback(mainException) && cacheException is ObjectNotValidException) {
+            if (operation.fallback(mainException, cacheException)) {
               getCache.getAll(query)
             } else {
               throw mainException

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
@@ -1,6 +1,5 @@
 package com.harmony.kotlin.data.repository
 
-import com.harmony.core.db.Cache
 import com.harmony.kotlin.data.datasource.DeleteDataSource
 import com.harmony.kotlin.data.datasource.GetDataSource
 import com.harmony.kotlin.data.datasource.PutDataSource

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/repository/CacheRepository.kt
@@ -31,8 +31,8 @@ class CacheRepository<V>(
       is DefaultOperation -> get(query, CacheSyncOperation())
       is MainOperation -> getMain.get(query)
       is CacheOperation -> {
-        val cacheValue = getCache.get(query)
         return try {
+          val cacheValue = getCache.get(query)
           if (!validator.isValid(cacheValue)) {
             throw ObjectNotValidException()
           } else {
@@ -40,7 +40,7 @@ class CacheRepository<V>(
           }
         } catch (cacheException: Exception) {
           if (operation.fallback(cacheException)) {
-            cacheValue
+            getCache.get(query)
           } else {
             throw cacheException
           }
@@ -84,8 +84,8 @@ class CacheRepository<V>(
       is DefaultOperation -> getAll(query, CacheSyncOperation())
       is MainOperation -> getMain.getAll(query)
       is CacheOperation -> {
-        val cacheValues = getCache.getAll(query)
         return try {
+          val cacheValues = getCache.getAll(query)
           val invalids = cacheValues.map { validator.isValid(it) }.filter { isValid -> !isValid }
           if (invalids.isNotEmpty()) {
             throw ObjectNotValidException()
@@ -94,7 +94,7 @@ class CacheRepository<V>(
           }
         } catch (cacheException: Exception) {
           if (operation.fallback(cacheException)) {
-            cacheValues
+            getCache.getAll(query)
           } else {
             throw cacheException
           }

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/VoidDataSourceObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/VoidDataSourceObjectMother.kt
@@ -1,0 +1,3 @@
+package com.harmony.kotlin.data.datasource
+
+fun <T> anyVoidDataSource() = VoidDataSource<T>()

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/memory/InMemoryDataSourceObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/memory/InMemoryDataSourceObjectMother.kt
@@ -1,0 +1,18 @@
+package com.harmony.kotlin.data.datasource.memory
+
+import com.harmony.kotlin.common.runTest
+import com.harmony.kotlin.data.utilities.InsertionValue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@OptIn(ExperimentalCoroutinesApi::class)
+fun <T> anyInMemoryDataSource(insertionValues: List<InsertionValue<T>> = emptyList()): InMemoryDataSource<T> {
+  val inMemoryDataSource = InMemoryDataSource<T>()
+
+  runTest {
+    insertionValues.forEach {
+      inMemoryDataSource.put(it.query, it.value)
+    }
+  }
+
+  return inMemoryDataSource
+}

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/memory/InMemoryDataSourceObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/memory/InMemoryDataSourceObjectMother.kt
@@ -2,15 +2,23 @@ package com.harmony.kotlin.data.datasource.memory
 
 import com.harmony.kotlin.common.runTest
 import com.harmony.kotlin.data.utilities.InsertionValue
+import com.harmony.kotlin.data.utilities.InsertionValues
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @OptIn(ExperimentalCoroutinesApi::class)
-fun <T> anyInMemoryDataSource(insertionValues: List<InsertionValue<T>> = emptyList()): InMemoryDataSource<T> {
+fun <T> anyInMemoryDataSource(
+  putValues: List<InsertionValue<T>> = emptyList(),
+  putAllValues: List<InsertionValues<T>> = emptyList()
+): InMemoryDataSource<T> {
   val inMemoryDataSource = InMemoryDataSource<T>()
 
   runTest {
-    insertionValues.forEach {
+    putValues.forEach {
       inMemoryDataSource.put(it.query, it.value)
+    }
+
+    putAllValues.forEach {
+      inMemoryDataSource.putAll(it.query, it.value)
     }
   }
 

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/operation/OperationObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/operation/OperationObjectMother.kt
@@ -1,0 +1,5 @@
+package com.harmony.kotlin.data.operation
+
+object AnyOperation: Operation()
+
+fun anyOperation() = AnyOperation

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/operation/OperationObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/operation/OperationObjectMother.kt
@@ -1,5 +1,5 @@
 package com.harmony.kotlin.data.operation
 
-object AnyOperation: Operation()
+object AnyOperation : Operation()
 
 fun anyOperation() = AnyOperation

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/operation/OperationObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/operation/OperationObjectMother.kt
@@ -1,5 +1,3 @@
 package com.harmony.kotlin.data.operation
 
-object AnyOperation : Operation()
-
-fun anyOperation() = AnyOperation
+fun anyOperation() = Operation()

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/query/QueryObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/query/QueryObjectMother.kt
@@ -1,0 +1,6 @@
+package com.harmony.kotlin.data.query
+
+import com.harmony.kotlin.common.randomString
+
+fun anyVoidQuery() = VoidQuery
+fun anyKeyQuery(key: String = randomString()) = KeyQuery(key)

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/query/QueryObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/query/QueryObjectMother.kt
@@ -2,5 +2,8 @@ package com.harmony.kotlin.data.query
 
 import com.harmony.kotlin.common.randomString
 
+fun anyQuery() = Query()
+
 fun anyVoidQuery() = VoidQuery
+
 fun anyKeyQuery(key: String = randomString()) = KeyQuery(key)

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
@@ -21,7 +21,6 @@ import com.harmony.kotlin.data.operation.MainSyncOperation
 import com.harmony.kotlin.data.operation.anyOperation
 import com.harmony.kotlin.data.query.anyKeyQuery
 import com.harmony.kotlin.data.query.anyQuery
-import com.harmony.kotlin.data.query.anyVoidQuery
 import com.harmony.kotlin.data.utilities.InsertionValue
 import com.harmony.kotlin.data.utilities.InsertionValues
 import com.harmony.kotlin.data.utilities.anyInsertionValue

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
@@ -15,16 +15,21 @@ import com.harmony.kotlin.data.operation.anyOperation
 import com.harmony.kotlin.data.query.anyKeyQuery
 import com.harmony.kotlin.data.query.anyVoidQuery
 import com.harmony.kotlin.data.utilities.InsertionValue
+import com.harmony.kotlin.data.utilities.InsertionValues
 import com.harmony.kotlin.data.utilities.anyInsertionValue
+import com.harmony.kotlin.data.utilities.anyInsertionValues
 import com.harmony.kotlin.data.validator.Validator
 import com.harmony.kotlin.data.validator.anyMockValidator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 @ExperimentalCoroutinesApi
 class CacheRepositoryTests {
+
+  //region get() - tests
 
   @Test
   fun `should retrieves the value from the main datasource when MainOperation is provided when get() is called`() = runTest {
@@ -114,6 +119,94 @@ class CacheRepositoryTests {
 
     assertEquals(expectedInsertionValue.value, value)
   }
+  //endregion
+
+  //region getAll() - tests
+
+  @Test
+  fun `should retrieves the value from the main datasource when MainOperation is provided when getAll() is called`() = runTest {
+    val expectedValues = anyInsertionValues()
+    val mainDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
+    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource)
+
+    val value = cacheRepository.getAll(expectedValues.query, MainOperation)
+
+    assertEquals(expectedValues.value.size, value.size)
+    assertContentEquals(expectedValues.value, value)
+  }
+
+  @Test
+  fun `should retrieves the value from the cache datasource when CacheOperation is provided when getAll() is called`() = runTest {
+    val expectedValues = anyInsertionValues()
+    val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
+    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+
+    val value = cacheRepository.getAll(expectedValues.query, CacheOperation())
+
+    assertContentEquals(expectedValues.value, value)
+  }
+
+  @Test
+  fun `should throw OperationNotAllowedException exception if invalid operation is provided when getAll() is called`() = runTest {
+    assertFailsWith<OperationNotAllowedException> {
+      val cacheRepository = givenCacheRepository<String>()
+      val invalidOperation = anyOperation()
+
+      cacheRepository.getAll(anyVoidQuery(), invalidOperation)
+    }
+  }
+
+  @Test
+  fun `should store the response from the main datasource into the cache datasource when MainSyncOperation is provided when getAll() is called`() = runTest {
+    val expectedValues = anyInsertionValues()
+    val mainDataSource = anyInMemoryDataSource(putAllValues = listOf(InsertionValues(expectedValues.query, expectedValues.value)))
+    val cacheDataSource = anyInMemoryDataSource<String>()
+    val cacheRepository = givenCacheRepository(mainDataSource, cacheDataSource)
+
+    val value = cacheRepository.getAll(expectedValues.query, MainSyncOperation)
+
+    assertContentEquals(expectedValues.value, value)
+
+    val expectedValueInCache = cacheDataSource.getAll(expectedValues.query)
+    assertContentEquals(expectedValues.value, expectedValueInCache)
+  }
+
+  @Test
+  fun `should response the value from the cache when CacheOperation is provided and there is values within the cache when getAll() is called`() = runTest {
+    val expectedValues = anyInsertionValues()
+    val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
+    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+
+    val value = cacheRepository.getAll(expectedValues.query, CacheOperation())
+
+    assertContentEquals(expectedValues.value, value)
+  }
+
+  @Test
+  fun `should throw ObjectNotValidException when the object is not valid from the cache when getAll() is called`() = runTest {
+    assertFailsWith<ObjectNotValidException> {
+      val expectedValues = anyInsertionValues()
+      val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
+      val validator = anyMockValidator<String>(validatorResponse = false)
+      val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+
+      cacheRepository.getAll(expectedValues.query, CacheOperation())
+    }
+  }
+
+  @Test
+  fun `should response the value from the cache when is invalid and CacheOperation fallback is set to true when getAll() called`() = runTest {
+    val expectedValues = anyInsertionValues()
+    val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
+    val validator = anyMockValidator<String>(validatorResponse = false)
+    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+
+    val cacheOperation = CacheOperation(fallback = { return@CacheOperation true })
+    val value = cacheRepository.getAll(expectedValues.query, cacheOperation)
+
+    assertContentEquals(expectedValues.value, value)
+  }
+  //endregion
 
   private fun <T> givenCacheRepository(
     mainDataSource: InMemoryDataSource<T> = anyInMemoryDataSource(),

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
@@ -44,7 +44,7 @@ class CacheRepositoryTests {
     val expectedValue = randomString()
     val anyQuery = anyKeyQuery(randomString())
     val mainDataSource = anyInMemoryDataSource(listOf(InsertionValue(anyQuery, expectedValue)))
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource)
+    val cacheRepository = givenCacheRepository(main = mainDataSource)
 
     val value = cacheRepository.get(anyQuery, MainOperation)
 
@@ -56,7 +56,7 @@ class CacheRepositoryTests {
     val expectedValue = randomString()
     val anyQuery = anyKeyQuery(randomString())
     val cacheDataSource = anyInMemoryDataSource(listOf(InsertionValue(anyQuery, expectedValue)))
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource)
 
     val value = cacheRepository.get(anyQuery, CacheOperation())
 
@@ -92,7 +92,7 @@ class CacheRepositoryTests {
   fun `should response the value from the cache when CacheOperation is provided and there is values within the cache when get() is called`() = runTest {
     val expectedInsertionValue = anyInsertionValue()
     val cacheDataSource = anyInMemoryDataSource(listOf(expectedInsertionValue))
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource)
 
     val value = cacheRepository.get(expectedInsertionValue.query, CacheOperation())
 
@@ -105,7 +105,7 @@ class CacheRepositoryTests {
       val anyInsertionValue = anyInsertionValue()
       val cacheDataSource = anyInMemoryDataSource(listOf(anyInsertionValue))
       val validator = anyMockValidator<String>(validatorResponse = false)
-      val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+      val cacheRepository = givenCacheRepository(cache = cacheDataSource, validator = validator)
 
       cacheRepository.get(anyInsertionValue.query, CacheOperation())
     }
@@ -118,7 +118,7 @@ class CacheRepositoryTests {
     val cacheDataSource = anyInMemoryDataSource(listOf(expectedInsertionValue))
 
     val validator = anyMockValidator<String>(validatorResponse = false)
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource, validator = validator)
 
     val cacheOperation = CacheOperation(fallback = { return@CacheOperation true })
     val value = cacheRepository.get(expectedInsertionValue.query, cacheOperation)
@@ -131,7 +131,7 @@ class CacheRepositoryTests {
     val expectedValue = anyInsertionValue()
     val cacheDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
     val validator = anyMockValidator<String>(true)
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource, validator = validator)
 
     val value = cacheRepository.get(expectedValue.query, CacheSyncOperation())
 
@@ -143,7 +143,7 @@ class CacheRepositoryTests {
     val expectedValue = anyInsertionValue()
     val cacheDataSource = anyInMemoryDataSource<String>()
     val mainDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource, cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(main = mainDataSource, cache = cacheDataSource)
 
     val value = cacheRepository.get(expectedValue.query, CacheSyncOperation())
     val cacheValue = cacheDataSource.get(expectedValue.query)
@@ -158,7 +158,7 @@ class CacheRepositoryTests {
     val cacheDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
     val mainDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
     val validator = anyMockValidator<String>(false)
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource, cacheDataSource = cacheDataSource, validator)
+    val cacheRepository = givenCacheRepository(main = mainDataSource, cache = cacheDataSource, validator)
 
     val value = cacheRepository.get(expectedValue.query, CacheSyncOperation())
     val cacheValue = cacheDataSource.get(expectedValue.query)
@@ -215,7 +215,7 @@ class CacheRepositoryTests {
     val expectedValue = anyInsertionValue()
     val cacheDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
     val validator = MockValidator<String>(false)
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource, validator = validator)
 
     val value = cacheRepository.get(expectedValue.query, CacheSyncOperation(fallback = { _, _ -> true }))
 
@@ -230,7 +230,7 @@ class CacheRepositoryTests {
   fun `should retrieves the value from the main datasource when MainOperation is provided when getAll() is called`() = runTest {
     val expectedValues = anyInsertionValues()
     val mainDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource)
+    val cacheRepository = givenCacheRepository(main = mainDataSource)
 
     val value = cacheRepository.getAll(expectedValues.query, MainOperation)
 
@@ -242,7 +242,7 @@ class CacheRepositoryTests {
   fun `should retrieves the value from the cache datasource when CacheOperation is provided when getAll() is called`() = runTest {
     val expectedValues = anyInsertionValues()
     val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource)
 
     val value = cacheRepository.getAll(expectedValues.query, CacheOperation())
 
@@ -277,7 +277,7 @@ class CacheRepositoryTests {
   fun `should response the value from the cache when CacheOperation is provided and there is values within the cache when getAll() is called`() = runTest {
     val expectedValues = anyInsertionValues()
     val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource)
 
     val value = cacheRepository.getAll(expectedValues.query, CacheOperation())
 
@@ -290,7 +290,7 @@ class CacheRepositoryTests {
       val expectedValues = anyInsertionValues()
       val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
       val validator = anyMockValidator<String>(validatorResponse = false)
-      val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+      val cacheRepository = givenCacheRepository(cache = cacheDataSource, validator = validator)
 
       cacheRepository.getAll(expectedValues.query, CacheOperation())
     }
@@ -301,7 +301,7 @@ class CacheRepositoryTests {
     val expectedValues = anyInsertionValues()
     val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
     val validator = anyMockValidator<String>(validatorResponse = false)
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource, validator = validator)
 
     val cacheOperation = CacheOperation(fallback = { return@CacheOperation true })
     val value = cacheRepository.getAll(expectedValues.query, cacheOperation)
@@ -309,13 +309,12 @@ class CacheRepositoryTests {
     assertContentEquals(expectedValues.value, value)
   }
 
-
   @Test
   fun `should return cache value when it's valid using CacheSyncOperation in getAll()`() = runTest {
     val expectedValues = anyInsertionValues()
     val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
     val validator = anyMockValidator<String>(true)
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource, validator = validator)
 
     val value = cacheRepository.getAll(expectedValues.query, CacheSyncOperation())
 
@@ -327,7 +326,7 @@ class CacheRepositoryTests {
     val expectedValues = anyInsertionValues()
     val cacheDataSource = anyInMemoryDataSource<String>()
     val mainDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource, cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(main = mainDataSource, cache = cacheDataSource)
 
     val value = cacheRepository.getAll(expectedValues.query, CacheSyncOperation())
     val cacheValue = cacheDataSource.getAll(expectedValues.query)
@@ -342,7 +341,7 @@ class CacheRepositoryTests {
     val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
     val mainDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
     val validator = anyMockValidator<String>(false)
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource, cacheDataSource = cacheDataSource, validator)
+    val cacheRepository = givenCacheRepository(main = mainDataSource, cache = cacheDataSource, validator)
 
     val value = cacheRepository.getAll(expectedValues.query, CacheSyncOperation())
     val cacheValue = cacheDataSource.getAll(expectedValues.query)
@@ -399,7 +398,7 @@ class CacheRepositoryTests {
     val expectedValues = anyInsertionValues()
     val cacheDataSource = anyInMemoryDataSource(putAllValues = listOf(expectedValues))
     val validator = MockValidator<String>(false)
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource, validator = validator)
 
     val value = cacheRepository.getAll(expectedValues.query, CacheSyncOperation(fallback = { _, _ -> true }))
 
@@ -413,7 +412,7 @@ class CacheRepositoryTests {
   @Test
   fun `should store value in main datasource when using MainOperation`() = runTest {
     val mainDataSource = anyInMemoryDataSource<String>()
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource)
+    val cacheRepository = givenCacheRepository(main = mainDataSource)
     val expectedValue = anyInsertionValue()
 
     val value = cacheRepository.put(expectedValue.query, expectedValue.value, MainOperation)
@@ -426,7 +425,7 @@ class CacheRepositoryTests {
   @Test
   fun `should store value in cache datasource when using CacheOperation`() = runTest {
     val cacheDataSource = anyInMemoryDataSource<String>()
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource)
     val expectedValue = anyInsertionValue()
 
     val value = cacheRepository.put(expectedValue.query, expectedValue.value, CacheOperation())
@@ -499,7 +498,7 @@ class CacheRepositoryTests {
   @Test
   fun `should store values in main datasource when using MainOperation`() = runTest {
     val mainDataSource = anyInMemoryDataSource<String>()
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource)
+    val cacheRepository = givenCacheRepository(main = mainDataSource)
     val expectedValues = anyInsertionValues()
 
     val value = cacheRepository.putAll(expectedValues.query, expectedValues.value, MainOperation)
@@ -512,7 +511,7 @@ class CacheRepositoryTests {
   @Test
   fun `should store values in cache datasource when using CacheOperation`() = runTest {
     val cacheDataSource = anyInMemoryDataSource<String>()
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource)
     val expectedValues = anyInsertionValues()
 
     val value = cacheRepository.putAll(expectedValues.query, expectedValues.value, CacheOperation())
@@ -599,7 +598,7 @@ class CacheRepositoryTests {
   fun `should delete value from the cache datasource when using CacheOperation`() = runTest {
     val expectedValue = anyInsertionValue()
     val cacheDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
-    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(cache = cacheDataSource)
 
     cacheRepository.delete(expectedValue.query, CacheOperation())
 
@@ -613,7 +612,7 @@ class CacheRepositoryTests {
     val expectedValue = anyInsertionValue()
     val mainDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
     val cacheDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource, cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(main = mainDataSource, cache = cacheDataSource)
 
     cacheRepository.delete(expectedValue.query, MainSyncOperation)
 
@@ -628,7 +627,7 @@ class CacheRepositoryTests {
     val expectedValue = anyInsertionValue()
     val mainDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
     val cacheDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))
-    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource, cacheDataSource = cacheDataSource)
+    val cacheRepository = givenCacheRepository(main = mainDataSource, cache = cacheDataSource)
 
     cacheRepository.delete(expectedValue.query, CacheSyncOperation())
 
@@ -649,13 +648,13 @@ class CacheRepositoryTests {
   //endregion
 
   private fun <T> givenCacheRepository(
-    mainDataSource: InMemoryDataSource<T> = anyInMemoryDataSource(),
-    cacheDataSource: InMemoryDataSource<T> = anyInMemoryDataSource(),
+    main: InMemoryDataSource<T> = anyInMemoryDataSource(),
+    cache: InMemoryDataSource<T> = anyInMemoryDataSource(),
     validator: Validator<T> = anyMockValidator()
   ): CacheRepository<T> {
     return CacheRepository(
-      cacheDataSource, cacheDataSource, cacheDataSource,
-      mainDataSource, mainDataSource, mainDataSource,
+      cache, cache, cache,
+      main, main, main,
       validator
     )
   }

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
@@ -1,0 +1,98 @@
+@file:Suppress("IllegalIdentifier")
+
+package com.harmony.kotlin.data.repository
+
+import com.harmony.kotlin.common.randomString
+import com.harmony.kotlin.common.runTest
+import com.harmony.kotlin.data.datasource.memory.InMemoryDataSource
+import com.harmony.kotlin.data.error.OperationNotAllowedException
+import com.harmony.kotlin.data.operation.*
+import com.harmony.kotlin.data.query.KeyQuery
+import com.harmony.kotlin.data.query.anyKeyQuery
+import com.harmony.kotlin.data.query.anyVoidQuery
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@ExperimentalCoroutinesApi
+class CacheRepositoryTests {
+
+  @Test
+  fun `should retrieves the value from the main datasource when MainOperation is provided when get() is called`() = runTest {
+    val expectedValue = randomString()
+    val anyQuery = anyKeyQuery(randomString())
+    val mainDataSource = givenInMemoryDataSource(listOf(InsertionValue(anyQuery, expectedValue)))
+    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource)
+
+    val value = cacheRepository.get(anyQuery, MainOperation)
+
+    assertEquals(expectedValue, value)
+  }
+
+  @Test
+  fun `should retrieves the value from the cache datasource when CacheOperation is provided when get() is called`() = runTest {
+    val expectedValue = randomString()
+    val anyQuery = anyKeyQuery(randomString())
+    val cacheDataSource = givenInMemoryDataSource(listOf(InsertionValue(anyQuery, expectedValue)))
+    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+
+    val value = cacheRepository.get(anyQuery, CacheOperation())
+
+    assertEquals(expectedValue, value)
+  }
+
+  @Test
+  fun `should throw OperationNotAllowedException exception if invalid operation is provided when get() is called`() = runTest {
+    assertFailsWith<OperationNotAllowedException> {
+      val cacheRepository = givenCacheRepository()
+      val invalidOperation = anyOperation()
+
+      cacheRepository.get(anyVoidQuery(), invalidOperation)
+    }
+  }
+
+  @Test
+  fun `should store the response from the main datasource into the cache datasource when MainSyncOperation is provided when get() is called`() = runTest {
+    val expectedValue = randomString()
+    val anyQuery = anyKeyQuery(randomString())
+    val insertionValues = listOf(InsertionValue(anyQuery, expectedValue))
+    val mainDataSource = givenInMemoryDataSource(insertionValues)
+    val cacheDataSource = givenInMemoryDataSource()
+    val cacheRepository = givenCacheRepository(mainDataSource, cacheDataSource)
+
+    val value = cacheRepository.get(anyQuery, MainSyncOperation)
+
+    assertEquals(expectedValue, value)
+
+    val expectedValueInCache = cacheDataSource.get(anyQuery)
+    assertEquals(expectedValue, expectedValueInCache)
+  }
+
+  data class InsertionValue(val query: KeyQuery, val value: String)
+
+  private fun givenInMemoryDataSource(insertionValues: List<InsertionValue> = emptyList()): InMemoryDataSource<String> {
+    val inMemoryDataSource = InMemoryDataSource<String>()
+
+    runTest {
+      insertionValues.forEach {
+        inMemoryDataSource.put(it.query, it.value)
+      }
+    }
+
+    return inMemoryDataSource
+  }
+
+  private fun givenCacheRepository(
+    mainDataSource: InMemoryDataSource<String> = givenInMemoryDataSource(),
+    cacheDataSource: InMemoryDataSource<String> = givenInMemoryDataSource(),
+  ): CacheRepository<String> {
+    val validator = CacheRepository.DefaultValidator<String>()
+
+    return CacheRepository(
+      cacheDataSource, cacheDataSource, cacheDataSource,
+      mainDataSource, mainDataSource, mainDataSource,
+      validator
+    )
+  }
+}

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
@@ -6,7 +6,10 @@ import com.harmony.kotlin.common.randomString
 import com.harmony.kotlin.common.runTest
 import com.harmony.kotlin.data.datasource.memory.InMemoryDataSource
 import com.harmony.kotlin.data.error.OperationNotAllowedException
-import com.harmony.kotlin.data.operation.*
+import com.harmony.kotlin.data.operation.CacheOperation
+import com.harmony.kotlin.data.operation.MainOperation
+import com.harmony.kotlin.data.operation.MainSyncOperation
+import com.harmony.kotlin.data.operation.anyOperation
 import com.harmony.kotlin.data.query.KeyQuery
 import com.harmony.kotlin.data.query.anyKeyQuery
 import com.harmony.kotlin.data.query.anyVoidQuery

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
@@ -10,6 +10,7 @@ import com.harmony.kotlin.data.error.ObjectNotValidException
 import com.harmony.kotlin.data.error.OperationNotAllowedException
 import com.harmony.kotlin.data.operation.CacheOperation
 import com.harmony.kotlin.data.operation.CacheSyncOperation
+import com.harmony.kotlin.data.operation.DefaultOperation
 import com.harmony.kotlin.data.operation.MainOperation
 import com.harmony.kotlin.data.operation.MainSyncOperation
 import com.harmony.kotlin.data.operation.anyOperation
@@ -254,7 +255,23 @@ class CacheRepositoryTests {
   }
 
   @Test
-  fun `should store the values first in cache datasouce and main datasource when using CacheSyncOperation`() = runTest {
+  fun `should replicate MainSyncOperation behaviour when DefaultOperation is provided using put()`() = runTest {
+    val cacheDataSource = anyInMemoryDataSource<String>()
+    val mainDataSource = anyInMemoryDataSource<String>()
+    val cacheRepository = givenCacheRepository(mainDataSource, cacheDataSource)
+    val expectedValue = anyInsertionValue()
+
+    val value = cacheRepository.put(expectedValue.query, expectedValue.value, DefaultOperation)
+    val mainDataSourceValue = mainDataSource.get(expectedValue.query)
+    val cacheDataSourceValue = cacheDataSource.get(expectedValue.query)
+
+    assertEquals(expectedValue.value, value)
+    assertEquals(expectedValue.value, mainDataSourceValue)
+    assertEquals(expectedValue.value, cacheDataSourceValue)
+  }
+
+  @Test
+  fun `should store the value first in cache datasouce and main datasource when using CacheSyncOperation`() = runTest {
     val cacheDataSource = anyInMemoryDataSource<String>()
     val mainDataSource = anyInMemoryDataSource<String>()
     val cacheRepository = givenCacheRepository(mainDataSource, cacheDataSource)
@@ -268,6 +285,87 @@ class CacheRepositoryTests {
     assertEquals(expectedValue.value, mainDataSourceValue)
     assertEquals(expectedValue.value, cacheDataSourceValue)
   }
+  //endregion
+
+  //region putAll() - tests
+
+  @Test
+  fun `should store values in main datasource when using MainOperation`() = runTest {
+    val mainDataSource = anyInMemoryDataSource<String>()
+    val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource)
+    val expectedValues = anyInsertionValues()
+
+    val value = cacheRepository.putAll(expectedValues.query, expectedValues.value, MainOperation)
+    val mainValue = mainDataSource.getAll(expectedValues.query)
+
+    assertContentEquals(expectedValues.value, value)
+    assertContentEquals(expectedValues.value, mainValue)
+  }
+
+  @Test
+  fun `should store values in cache datasource when using CacheOperation`() = runTest {
+    val cacheDataSource = anyInMemoryDataSource<String>()
+    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
+    val expectedValues = anyInsertionValues()
+
+    val value = cacheRepository.putAll(expectedValues.query, expectedValues.value, CacheOperation())
+    val mainValue = cacheDataSource.getAll(expectedValues.query)
+
+    assertContentEquals(expectedValues.value, value)
+    assertContentEquals(expectedValues.value, mainValue)
+  }
+
+  @Test
+  fun `should store the values first in main datasouce and cache datasource when using MainSyncOperation`() = runTest {
+    val cacheDataSource = anyInMemoryDataSource<String>()
+    val mainDataSource = anyInMemoryDataSource<String>()
+    val cacheRepository = givenCacheRepository(mainDataSource, cacheDataSource)
+    val expectedValues = anyInsertionValues()
+
+    val value = cacheRepository.putAll(expectedValues.query, expectedValues.value, MainSyncOperation)
+    val mainDataSourceValue = mainDataSource.getAll(expectedValues.query)
+    val cacheDataSourceValue = cacheDataSource.getAll(expectedValues.query)
+
+    assertContentEquals(expectedValues.value, value)
+    assertContentEquals(expectedValues.value, mainDataSourceValue)
+    assertContentEquals(expectedValues.value, cacheDataSourceValue)
+  }
+
+  @Test
+  fun `should replicate MainSyncOperation behaviour when DefaultOperation is provided`() = runTest {
+    val cacheDataSource = anyInMemoryDataSource<String>()
+    val mainDataSource = anyInMemoryDataSource<String>()
+    val cacheRepository = givenCacheRepository(mainDataSource, cacheDataSource)
+    val expectedValues = anyInsertionValues()
+
+    val value = cacheRepository.putAll(expectedValues.query, expectedValues.value, DefaultOperation)
+    val mainDataSourceValue = mainDataSource.getAll(expectedValues.query)
+    val cacheDataSourceValue = cacheDataSource.getAll(expectedValues.query)
+
+    assertContentEquals(expectedValues.value, value)
+    assertContentEquals(expectedValues.value, mainDataSourceValue)
+    assertContentEquals(expectedValues.value, cacheDataSourceValue)
+  }
+
+  @Test
+  fun `should store the values first in cache datasouce and main datasource when using CacheSyncOperation`() = runTest {
+    val cacheDataSource = anyInMemoryDataSource<String>()
+    val mainDataSource = anyInMemoryDataSource<String>()
+    val cacheRepository = givenCacheRepository(mainDataSource, cacheDataSource)
+    val expectedValues = anyInsertionValues()
+
+    val value = cacheRepository.putAll(expectedValues.query, expectedValues.value, CacheSyncOperation())
+    val cacheDataSourceValue = cacheDataSource.getAll(expectedValues.query)
+    val mainDataSourceValue = mainDataSource.getAll(expectedValues.query)
+
+    assertContentEquals(expectedValues.value, value)
+    assertContentEquals(expectedValues.value, mainDataSourceValue)
+    assertContentEquals(expectedValues.value, cacheDataSourceValue)
+  }
+  //endregion
+
+  //region delete() - tests
+
   //endregion
 
   private fun <T> givenCacheRepository(

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
@@ -60,12 +60,10 @@ class CacheRepositoryTests {
   }
 
   @Test
-  fun `should throw OperationNotAllowedException exception if invalid operation is provided when get() is called`() = runTest {
+  fun `should throw operation not allowed using get()`() = runTest {
+    val cacheRepository = givenCacheRepository<String>()
     assertFailsWith<OperationNotAllowedException> {
-      val cacheRepository = givenCacheRepository<String>()
-      val invalidOperation = anyOperation()
-
-      cacheRepository.get(anyVoidQuery(), invalidOperation)
+      cacheRepository.get(anyQuery(), anyOperation())
     }
   }
 
@@ -151,12 +149,11 @@ class CacheRepositoryTests {
   }
 
   @Test
-  fun `should throw OperationNotAllowedException exception if invalid operation is provided when getAll() is called`() = runTest {
-    assertFailsWith<OperationNotAllowedException> {
-      val cacheRepository = givenCacheRepository<String>()
-      val invalidOperation = anyOperation()
+  fun `should throw operation not allowed using getAll()`() = runTest {
+    val cacheRepository = givenCacheRepository<String>()
 
-      cacheRepository.getAll(anyVoidQuery(), invalidOperation)
+    assertFailsWith<OperationNotAllowedException> {
+      cacheRepository.getAll(anyQuery(), anyOperation())
     }
   }
 
@@ -287,6 +284,15 @@ class CacheRepositoryTests {
     assertEquals(expectedValue.value, mainDataSourceValue)
     assertEquals(expectedValue.value, cacheDataSourceValue)
   }
+
+  @Test
+  fun `should throw operation not allowed using put()`() = runTest {
+    val cacheRepository = givenCacheRepository<String>()
+
+    assertFailsWith<OperationNotAllowedException> {
+      cacheRepository.put(anyQuery(), randomString(), anyOperation())
+    }
+  }
   //endregion
 
   //region putAll() - tests
@@ -364,6 +370,15 @@ class CacheRepositoryTests {
     assertContentEquals(expectedValues.value, mainDataSourceValue)
     assertContentEquals(expectedValues.value, cacheDataSourceValue)
   }
+
+  @Test
+  fun `should throw operation not allowed using putAll()`() = runTest {
+    val cacheRepository = givenCacheRepository<String>()
+
+    assertFailsWith<OperationNotAllowedException> {
+      cacheRepository.putAll(anyQuery(), listOf(randomString()), anyOperation())
+    }
+  }
   //endregion
 
   //region delete() - tests
@@ -432,7 +447,6 @@ class CacheRepositoryTests {
       cacheRepository.delete(anyQuery(), anyOperation())
     }
   }
-
   //endregion
 
   private fun <T> givenCacheRepository(

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
@@ -5,14 +5,19 @@ package com.harmony.kotlin.data.repository
 import com.harmony.kotlin.common.randomString
 import com.harmony.kotlin.common.runTest
 import com.harmony.kotlin.data.datasource.memory.InMemoryDataSource
+import com.harmony.kotlin.data.datasource.memory.anyInMemoryDataSource
+import com.harmony.kotlin.data.error.ObjectNotValidException
 import com.harmony.kotlin.data.error.OperationNotAllowedException
 import com.harmony.kotlin.data.operation.CacheOperation
 import com.harmony.kotlin.data.operation.MainOperation
 import com.harmony.kotlin.data.operation.MainSyncOperation
 import com.harmony.kotlin.data.operation.anyOperation
-import com.harmony.kotlin.data.query.KeyQuery
 import com.harmony.kotlin.data.query.anyKeyQuery
 import com.harmony.kotlin.data.query.anyVoidQuery
+import com.harmony.kotlin.data.utilities.InsertionValue
+import com.harmony.kotlin.data.utilities.anyInsertionValue
+import com.harmony.kotlin.data.validator.Validator
+import com.harmony.kotlin.data.validator.anyMockValidator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,7 +30,7 @@ class CacheRepositoryTests {
   fun `should retrieves the value from the main datasource when MainOperation is provided when get() is called`() = runTest {
     val expectedValue = randomString()
     val anyQuery = anyKeyQuery(randomString())
-    val mainDataSource = givenInMemoryDataSource(listOf(InsertionValue(anyQuery, expectedValue)))
+    val mainDataSource = anyInMemoryDataSource(listOf(InsertionValue(anyQuery, expectedValue)))
     val cacheRepository = givenCacheRepository(mainDataSource = mainDataSource)
 
     val value = cacheRepository.get(anyQuery, MainOperation)
@@ -37,7 +42,7 @@ class CacheRepositoryTests {
   fun `should retrieves the value from the cache datasource when CacheOperation is provided when get() is called`() = runTest {
     val expectedValue = randomString()
     val anyQuery = anyKeyQuery(randomString())
-    val cacheDataSource = givenInMemoryDataSource(listOf(InsertionValue(anyQuery, expectedValue)))
+    val cacheDataSource = anyInMemoryDataSource(listOf(InsertionValue(anyQuery, expectedValue)))
     val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
 
     val value = cacheRepository.get(anyQuery, CacheOperation())
@@ -48,7 +53,7 @@ class CacheRepositoryTests {
   @Test
   fun `should throw OperationNotAllowedException exception if invalid operation is provided when get() is called`() = runTest {
     assertFailsWith<OperationNotAllowedException> {
-      val cacheRepository = givenCacheRepository()
+      val cacheRepository = givenCacheRepository<String>()
       val invalidOperation = anyOperation()
 
       cacheRepository.get(anyVoidQuery(), invalidOperation)
@@ -60,8 +65,8 @@ class CacheRepositoryTests {
     val expectedValue = randomString()
     val anyQuery = anyKeyQuery(randomString())
     val insertionValues = listOf(InsertionValue(anyQuery, expectedValue))
-    val mainDataSource = givenInMemoryDataSource(insertionValues)
-    val cacheDataSource = givenInMemoryDataSource()
+    val mainDataSource = anyInMemoryDataSource(insertionValues)
+    val cacheDataSource = anyInMemoryDataSource<String>()
     val cacheRepository = givenCacheRepository(mainDataSource, cacheDataSource)
 
     val value = cacheRepository.get(anyQuery, MainSyncOperation)
@@ -72,26 +77,49 @@ class CacheRepositoryTests {
     assertEquals(expectedValue, expectedValueInCache)
   }
 
-  data class InsertionValue(val query: KeyQuery, val value: String)
+  @Test
+  fun `should response the value from the cache when CacheOperation is provided and there is values within the cache when get() is called`() = runTest {
+    val expectedInsertionValue = anyInsertionValue()
+    val cacheDataSource = anyInMemoryDataSource(listOf(expectedInsertionValue))
+    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource)
 
-  private fun givenInMemoryDataSource(insertionValues: List<InsertionValue> = emptyList()): InMemoryDataSource<String> {
-    val inMemoryDataSource = InMemoryDataSource<String>()
+    val value = cacheRepository.get(expectedInsertionValue.query, CacheOperation())
 
-    runTest {
-      insertionValues.forEach {
-        inMemoryDataSource.put(it.query, it.value)
-      }
-    }
-
-    return inMemoryDataSource
+    assertEquals(expectedInsertionValue.value, value)
   }
 
-  private fun givenCacheRepository(
-    mainDataSource: InMemoryDataSource<String> = givenInMemoryDataSource(),
-    cacheDataSource: InMemoryDataSource<String> = givenInMemoryDataSource(),
-  ): CacheRepository<String> {
-    val validator = CacheRepository.DefaultValidator<String>()
+  @Test
+  fun `should throw ObjectNotValidException when the object is not valid from the cache when get() is called`() = runTest {
+    assertFailsWith<ObjectNotValidException> {
+      val anyInsertionValue = anyInsertionValue()
+      val cacheDataSource = anyInMemoryDataSource(listOf(anyInsertionValue))
+      val validator = anyMockValidator<String>(validatorResponse = false)
+      val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
 
+      cacheRepository.get(anyInsertionValue.query, CacheOperation())
+    }
+  }
+
+  @Test
+  fun `should response the value from the cache when is invalid and CacheOperation fallback is set to true when get() called`() = runTest {
+    val expectedInsertionValue = anyInsertionValue()
+
+    val cacheDataSource = anyInMemoryDataSource(listOf(expectedInsertionValue))
+
+    val validator = anyMockValidator<String>(validatorResponse = false)
+    val cacheRepository = givenCacheRepository(cacheDataSource = cacheDataSource, validator = validator)
+
+    val cacheOperation = CacheOperation(fallback = { return@CacheOperation true })
+    val value = cacheRepository.get(expectedInsertionValue.query, cacheOperation)
+
+    assertEquals(expectedInsertionValue.value, value)
+  }
+
+  private fun <T> givenCacheRepository(
+    mainDataSource: InMemoryDataSource<T> = anyInMemoryDataSource(),
+    cacheDataSource: InMemoryDataSource<T> = anyInMemoryDataSource(),
+    validator: Validator<T> = anyMockValidator()
+  ): CacheRepository<T> {
     return CacheRepository(
       cacheDataSource, cacheDataSource, cacheDataSource,
       mainDataSource, mainDataSource, mainDataSource,

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/repository/CacheRepositoryTests.kt
@@ -112,7 +112,7 @@ class CacheRepositoryTests {
   }
 
   @Test
-  fun `should response the value from the cache when calling get() with CacheOperation given that the object is not valid and CacheOperation.fallback returns true`() =
+  fun `should get cached value when calling get() with CacheOperation given that the object is not valid and fallback returns true`() =
     runTest {
       val expectedInsertionValue = anyInsertionValue()
 
@@ -198,7 +198,7 @@ class CacheRepositoryTests {
     }
 
   @Test
-  fun `should throw exception when calling get() with CacheSyncOperation given that cache throws the exception and CacheSyncOperation.fallback returns false`() =
+  fun `should throw exception when calling get() with CacheSyncOperation given that cache throws a exception and fallback returns false`() =
     runTest {
       val mainDataSource = anyVoidDataSource<String>()
       val cacheDataSource = anyVoidDataSource<String>()
@@ -215,7 +215,7 @@ class CacheRepositoryTests {
 
   @Test
   fun
-    `should get cached value when calling get() with CacheSyncOperation given that cached value isn't valid and CacheSyncOperation.fallback returns true`() =
+  `should get cached value when calling get() with CacheSyncOperation given that cached value isn't valid and fallback returns true`() =
     runTest {
       val expectedValue = anyInsertionValue()
       val cacheDataSource = anyInMemoryDataSource(putValues = listOf(expectedValue))

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/utilities/InsertionValue.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/utilities/InsertionValue.kt
@@ -3,3 +3,5 @@ package com.harmony.kotlin.data.utilities
 import com.harmony.kotlin.data.query.KeyQuery
 
 data class InsertionValue<T>(val query: KeyQuery, val value: T?)
+
+data class InsertionValues<T>(val query: KeyQuery, val value: List<T>)

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/utilities/InsertionValue.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/utilities/InsertionValue.kt
@@ -1,0 +1,5 @@
+package com.harmony.kotlin.data.utilities
+
+import com.harmony.kotlin.data.query.KeyQuery
+
+data class InsertionValue<T>(val query: KeyQuery, val value: T?)

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/utilities/InsertionValueObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/utilities/InsertionValueObjectMother.kt
@@ -1,0 +1,6 @@
+package com.harmony.kotlin.data.utilities
+
+import com.harmony.kotlin.common.randomString
+import com.harmony.kotlin.data.query.anyKeyQuery
+
+fun anyInsertionValue() = InsertionValue(anyKeyQuery(randomString()), randomString())

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/utilities/InsertionValueObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/utilities/InsertionValueObjectMother.kt
@@ -1,6 +1,13 @@
 package com.harmony.kotlin.data.utilities
 
+import com.harmony.kotlin.common.randomInt
 import com.harmony.kotlin.common.randomString
 import com.harmony.kotlin.data.query.anyKeyQuery
 
 fun anyInsertionValue() = InsertionValue(anyKeyQuery(randomString()), randomString())
+
+fun anyInsertionValues(): InsertionValues<String> {
+  val elements = randomInt(0, 10)
+  val randomValues = (0..elements).map { randomString() }.toList()
+  return InsertionValues(anyKeyQuery(randomString()), randomValues)
+}

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/validator/ValidatorObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/validator/ValidatorObjectMother.kt
@@ -1,0 +1,5 @@
+package com.harmony.kotlin.data.validator
+
+import com.harmony.kotlin.data.validator.mock.MockValidator
+
+fun <T> anyMockValidator(validatorResponse: Boolean = true) = MockValidator<T>(forceValidationResponse = validatorResponse)

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/validator/mock/MockValidator.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/validator/mock/MockValidator.kt
@@ -1,0 +1,7 @@
+package com.harmony.kotlin.data.validator.mock
+
+import com.harmony.kotlin.data.validator.Validator
+
+class MockValidator<T>(private val forceValidationResponse: Boolean) : Validator<T> {
+  override fun isValid(value: T): Boolean = forceValidationResponse
+}


### PR DESCRIPTION
Goal was to remove the hardcode business logic of allowing the `ObjectNotValidException` in the fallback operation and give the whole power to the fallback