### PR TITLE
NetworkQuery: Support for call with empty body when using ContentType.Json

### DIFF
--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/NetworkQuery.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/NetworkQuery.kt
@@ -126,9 +126,9 @@ open class NetworkQuery(
 
     /**
      *  application/json http content type
-     *  @param entity json serializable object
+     *  @param entity optional json serializable object, if null the body of the call will be empty.
      */
-    class Json<T>(val entity: T) : ContentType() {
+    class Json<T>(val entity: T?) : ContentType() {
       override fun toString(): String {
         return "application/json : $entity"
       }

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/NetworkQueryToKtorExtensions.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/NetworkQueryToKtorExtensions.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.request
 import io.ktor.client.request.url
+import io.ktor.client.utils.EmptyContent
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.Parameters
@@ -41,7 +42,7 @@ internal suspend fun NetworkQuery.executeKtorRequest(httpClient: HttpClient, bas
         }
         is NetworkQuery.ContentType.Json<*> -> {
           contentType(ContentType.Application.Json)
-          body = contentType.entity!!
+          body = contentType.entity ?: EmptyContent
         }
       }
     }


### PR DESCRIPTION
This PR make is possible to use GenericNetworkDataSource to make a POST or PUT call with content-type "application/json" and with an empty body.