### PR TITLE
Add support for Queries to be composed of other queries

### DIFF
--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/ComposableNetworkQuery.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/ComposableNetworkQuery.kt
@@ -1,0 +1,10 @@
+package com.harmony.kotlin.data.datasource.network
+
+import com.harmony.kotlin.data.query.Query
+
+/**
+ * Query that defines a dependency on a NetworkQuery, useful when two different DataSources (Network & any other) needs to use different queries.
+ */
+interface ComposableNetworkQuery : Query {
+  val networkQuery: NetworkQuery
+}

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkDataSource.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/datasource/network/GenericNetworkDataSource.kt
@@ -47,15 +47,14 @@ class GetNetworkDataSource<T>(
     validateQuery(query).executeKtorRequest(httpClient = httpClient, baseUrl = url, globalHeaders = globalHeaders)
 
   private fun validateQuery(query: Query): NetworkQuery {
-    if (query !is NetworkQuery) {
-      throw QueryNotSupportedException("GetNetworkDataSource only supports NetworkQuery")
+    val networkQuery = query.validateAndUnwrapQuery()
+
+    NetworkQuery.Method.Delete::class
+    if (networkQuery.method !is NetworkQuery.Method.Delete) {
+      throw QueryNotSupportedException("NetworkQuery method is ${networkQuery.method} instead of GET")
     }
 
-    if (query.method !is NetworkQuery.Method.Get) {
-      throw QueryNotSupportedException("NetworkQuery method is ${query.method} instead of GET")
-    }
-
-    return query
+    return networkQuery
   }
 }
 
@@ -129,15 +128,14 @@ class PutNetworkDataSource<T>(
   }
 
   private fun validateQuery(query: Query): NetworkQuery {
-    if (query !is NetworkQuery) {
-      throw QueryNotSupportedException("GetNetworkDataSource only supports NetworkQuery")
+    val networkQuery = query.validateAndUnwrapQuery()
+
+    NetworkQuery.Method.Delete::class
+    if (networkQuery.method !is NetworkQuery.Method.Delete) {
+      throw QueryNotSupportedException("NetworkQuery method is ${networkQuery.method} instead of POST or PUT")
     }
 
-    if (query.method !is NetworkQuery.Method.Post && query.method !is NetworkQuery.Method.Put) {
-      throw QueryNotSupportedException("NetworkQuery method is ${query.method} instead of POST or PUT")
-    }
-
-    return query
+    return networkQuery
   }
 }
 
@@ -158,15 +156,28 @@ class DeleteNetworkDataSource(
   }
 
   private fun validateQuery(query: Query): NetworkQuery {
-    if (query !is NetworkQuery) {
-      throw QueryNotSupportedException("DeleteNetworkDataSource only supports NetworkQuery")
+    val networkQuery = query.validateAndUnwrapQuery()
+
+    NetworkQuery.Method.Delete::class
+    if (networkQuery.method !is NetworkQuery.Method.Delete) {
+      throw QueryNotSupportedException("NetworkQuery method is ${networkQuery.method} instead of DELETE")
     }
 
-    if (query.method !is NetworkQuery.Method.Delete) {
-      throw QueryNotSupportedException("NetworkQuery method is ${query.method} instead of DELETE")
-    }
+    return networkQuery
+  }
+}
 
-    return query
+private fun Query.validateAndUnwrapQuery(): NetworkQuery {
+  return when (this) {
+    is ComposableNetworkQuery -> {
+      this.networkQuery
+    }
+    is NetworkQuery -> {
+      this
+    }
+    else -> {
+      throw QueryNotSupportedException("NetworkDataSource only supports NetworkQuery")
+    }
   }
 }
 

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/query/Query.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/data/query/Query.kt
@@ -2,15 +2,15 @@ package com.harmony.kotlin.data.query
 
 // Queries
 
-open class Query
+interface Query
 
-object VoidQuery : Query()
+object VoidQuery : Query
 
 // Single object query
-open class ObjectQuery<out T>(val value: T) : Query()
+open class ObjectQuery<out T>(val value: T) : Query
 
 // Collection objects query
-open class ObjectsQuery<out T>(val values: Collection<T>) : Query()
+open class ObjectsQuery<out T>(val values: Collection<T>) : Query
 
 // Generic all object query supporting key value
 open class AllObjectsQuery : KeyQuery("all-objects-key")
@@ -30,13 +30,7 @@ open class PaginationQuery(identifier: String) : KeyQuery(identifier)
 open class PaginationOffsetLimitQuery(identifier: String, val offset: Int, val limit: Int) : PaginationQuery("$identifier-$offset-$limit")
 
 // Key value queries
-open class KeyQuery(val key: String /* key associated to the query */) : Query()
+open class KeyQuery(val key: String /* key associated to the query */) : Query
 
 // Extensions
 inline fun <reified T> IdQuery<*>.asTyped(): IdQuery<T>? = (this.identifier as? T)?.let { IdQuery(it) }
-
-// inline fun <reified T> KeyQuery<*>.asTyped(): KeyQuery<T>? = (this.key as? T)?.let { KeyQuery(it) }
-
-// fun <T> KeyQuery<*>.isTyped(type: Class<T>): Boolean {
-//  return type.isAssignableFrom(this.key!!::class.java.componentType)
-// }

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/query/QueryObjectMother.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/query/QueryObjectMother.kt
@@ -2,7 +2,7 @@ package com.harmony.kotlin.data.query
 
 import com.harmony.kotlin.common.randomString
 
-fun anyQuery() = Query()
+fun anyQuery() = object : Query {}
 
 fun anyVoidQuery() = VoidQuery
 


### PR DESCRIPTION
This PR adds support for a Query to be composed of other queries (making Query an interface) & also defines a ComposableNetworkQuery that is supported by the generic network datasource.

This is useful in the use case in which we have two different data sources that need entirely different queries. 

This is the solution after encountering the following problem in a project:
 - We have a CacheRepository with Network & custom storage.
 - For the storage to work we are only required to define a couple of queries.
 - For the network, we have a much larger number of queries
 - Network and Storage queries were mostly unrelated.
 - In this case, the best approach is to not depend on inheritance from NetworkQuery and use composition.

Some sample usage:
```kotlin
interface ComposableCustomStorageQuery: Query {
  val customStorageQuery: CustomStorageQuery
}

class MyComposedQuery: ComposableNetworkQuery, ComposableCustomStorageQuery {
  override val networkQuery: NetworkQuery
    get() = TODO("Create NeworkQuery based on constructor arguments")
  override val customStorageQuery: CustomStorageQuery
    get() = TODO("Create CustomStorageQuery based on constructor arguments")
}
```

