### PR TITLE
feature: Add PresenterViewHolder

### DIFF
--- a/harmony-kotlin/build.gradle.kts
+++ b/harmony-kotlin/build.gradle.kts
@@ -137,6 +137,7 @@ kotlin {
         implementation("androidx.test:rules:1.4.0")
         implementation("androidx.test.ext:junit-ktx:1.1.3")
         implementation("org.robolectric:robolectric:4.7.1")
+        implementation("androidx.lifecycle:lifecycle-runtime-testing:2.4.1")
       }
     }
     val iosX64Main by getting

--- a/harmony-kotlin/src/androidMain/kotlin/com/harmony/kotlin/common/presenter/PresenterViewHolder.kt
+++ b/harmony-kotlin/src/androidMain/kotlin/com/harmony/kotlin/common/presenter/PresenterViewHolder.kt
@@ -1,0 +1,26 @@
+package com.harmony.kotlin.common.presenter
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import java.lang.ref.WeakReference
+
+// View holder that removes the view reference as soon as view's onDestroy is called.
+actual class PresenterViewHolder<V : Any> actual constructor(view: V) : DefaultLifecycleObserver {
+
+  private val view: WeakReference<V> = WeakReference(view)
+
+  init {
+    if (view is LifecycleOwner) {
+      view.lifecycle.addObserver(this)
+    }
+  }
+
+  actual fun get(): V? {
+    return view.get()
+  }
+
+  override fun onDestroy(owner: LifecycleOwner) {
+    super.onDestroy(owner)
+    view.clear()
+  }
+}

--- a/harmony-kotlin/src/androidTest/kotlin/com/harmony/kotlin/CoroutinesTestRule.kt
+++ b/harmony-kotlin/src/androidTest/kotlin/com/harmony/kotlin/CoroutinesTestRule.kt
@@ -1,0 +1,26 @@
+package com.harmony.kotlin
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class CoroutinesTestRule(
+  private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+
+  override fun starting(description: Description?) {
+    super.starting(description)
+    Dispatchers.setMain(testDispatcher)
+  }
+
+  override fun finished(description: Description?) {
+    super.finished(description)
+    Dispatchers.resetMain()
+  }
+}

--- a/harmony-kotlin/src/androidTest/kotlin/com/harmony/kotlin/common/presenter/PresenterViewHolderTest.kt
+++ b/harmony-kotlin/src/androidTest/kotlin/com/harmony/kotlin/common/presenter/PresenterViewHolderTest.kt
@@ -1,0 +1,40 @@
+package com.harmony.kotlin.common.presenter
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import com.harmony.kotlin.CoroutinesTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertNotNull
+
+class PresenterViewHolderTest {
+
+  @get:Rule
+  val coroutinesTestRule = CoroutinesTestRule()
+
+  @Test
+  fun `assert view reference is cleared when lifecycle reaches destroyed state`() = runTest {
+    val lifecycleOwner = TestLifecycleOwner()
+    val viewHolder = PresenterViewHolder(lifecycleOwner)
+
+    lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+    assertNull(viewHolder.get())
+  }
+
+  @Test
+  fun `assert view is not null when lifecycle reaches any state except destroyed`() = runTest {
+    val lifecycleOwner = TestLifecycleOwner()
+    val viewHolder = PresenterViewHolder(lifecycleOwner)
+    val nonDestroyedState = Lifecycle.Event.values()
+      .toMutableList()
+      .minus(listOf(Lifecycle.Event.ON_DESTROY, Lifecycle.Event.ON_ANY))
+      .random()
+
+    lifecycleOwner.handleLifecycleEvent(nonDestroyedState)
+
+    assertNotNull(viewHolder.get())
+  }
+}

--- a/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/common/presenter/PresenterViewHolder.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com.harmony.kotlin/common/presenter/PresenterViewHolder.kt
@@ -1,0 +1,8 @@
+package com.harmony.kotlin.common.presenter
+
+/**
+ * Holds a view for a Presenter. Intended to avoid memory leaks and handle view lifecycle (when applies)
+ */
+expect class PresenterViewHolder<V : Any>(view: V) {
+  fun get(): V?
+}

--- a/harmony-kotlin/src/iosMain/kotlin/com/harmony/kotlin/common/presenter/PresenterViewHolder.kt
+++ b/harmony-kotlin/src/iosMain/kotlin/com/harmony/kotlin/common/presenter/PresenterViewHolder.kt
@@ -1,0 +1,13 @@
+package com.harmony.kotlin.common.presenter
+
+import com.harmony.kotlin.common.WeakReference
+
+// View holder that avoid memory leaks using a WeakReference
+actual class PresenterViewHolder<V : Any> actual constructor(view: V) {
+
+  private val view: WeakReference<V> = WeakReference(view)
+
+  actual fun get(): V? {
+    return view.get()
+  }
+}

--- a/harmony-kotlin/src/jvmMain/kotlin/com/harmony/kotlin/common/presenter/PresenterViewHolder.kt
+++ b/harmony-kotlin/src/jvmMain/kotlin/com/harmony/kotlin/common/presenter/PresenterViewHolder.kt
@@ -1,0 +1,13 @@
+package com.harmony.kotlin.common.presenter
+
+import com.harmony.kotlin.common.WeakReference
+
+// View holder that avoid memory leaks using a WeakReference
+actual class PresenterViewHolder<V : Any> actual constructor(view: V) {
+
+  private val view = WeakReference(view)
+
+  actual fun get(): V? {
+    return this.view.get()
+  }
+}

--- a/sample-android/src/main/java/com/mobilejazz/kmmsample/application/ui/screen/hackerpost/HackerPostsActivity.kt
+++ b/sample-android/src/main/java/com/mobilejazz/kmmsample/application/ui/screen/hackerpost/HackerPostsActivity.kt
@@ -2,15 +2,15 @@ package com.mobilejazz.kmmsample.application.ui.screen.hackerpost
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import com.mobilejazz.kmmsample.application.HarmonySampleApp
 import com.mobilejazz.kmmsample.application.R
 import com.mobilejazz.kmmsample.application.databinding.ActivityHackerPostsBinding
-import com.mobilejazz.kmmsample.application.ui.common.BaseActivity
 import com.mobilejazz.kmmsample.application.ui.common.toLocalizedErrorMessage
 import com.mobilejazz.kmmsample.core.feature.hackerposts.domain.model.HackerNewsPosts
 import com.mobilejazz.kmmsample.core.screen.hackerposts.HackerPostsPresenter
 
-class HackerPostsActivity : BaseActivity(), HackerPostsPresenter.View {
+class HackerPostsActivity : AppCompatActivity(), HackerPostsPresenter.View {
 
   private lateinit var binding: ActivityHackerPostsBinding
   private val presenter by lazy {

--- a/sample-android/src/main/java/com/mobilejazz/kmmsample/application/ui/screen/hackerpost/HackerPostsActivity.kt
+++ b/sample-android/src/main/java/com/mobilejazz/kmmsample/application/ui/screen/hackerpost/HackerPostsActivity.kt
@@ -45,9 +45,4 @@ class HackerPostsActivity : AppCompatActivity(), HackerPostsPresenter.View {
   override fun onFailedWithFullScreenError(t: Throwable, retryBlock: () -> Unit) {
     binding.loadContentLayout.showError(t.toLocalizedErrorMessage(this), R.string.ls_retry, retryBlock)
   }
-
-  override fun onStop() {
-    super.onStop()
-    presenter.onDetachView()
-  }
 }

--- a/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/PresenterProvider.kt
+++ b/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/PresenterProvider.kt
@@ -1,7 +1,7 @@
 package com.mobilejazz.kmmsample.core.screen
 
-import com.harmony.kotlin.common.WeakReference
 import com.harmony.kotlin.common.logger.Logger
+import com.harmony.kotlin.common.presenter.PresenterViewHolder
 import com.mobilejazz.kmmsample.core.feature.hackerposts.HackerNewsPostsComponent
 import com.mobilejazz.kmmsample.core.screen.hackerposts.HackerPostDetailDefaultPresenter
 import com.mobilejazz.kmmsample.core.screen.hackerposts.HackerPostDetailPresenter
@@ -19,7 +19,7 @@ class PresenterDefaultModule(
 ) : PresenterComponent {
   override fun getHackerPostsPresenter(view: HackerPostsPresenter.View): HackerPostsPresenter {
     return HackerPostsDefaultPresenter(
-      WeakReference(view),
+      PresenterViewHolder(view),
       hackerNewsPostsComponent.getHackerNewsPostsInteractor(),
       logger
     )

--- a/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/hackerposts/HackerPostsPresenter.kt
+++ b/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/hackerposts/HackerPostsPresenter.kt
@@ -1,8 +1,8 @@
 package com.mobilejazz.kmmsample.core.screen.hackerposts
 
-import com.harmony.kotlin.common.WeakReference
 import com.harmony.kotlin.common.logger.Logger
 import com.harmony.kotlin.common.onComplete
+import com.harmony.kotlin.common.presenter.PresenterViewHolder
 import com.mobilejazz.kmmsample.core.feature.hackerposts.domain.interactor.GetHackerNewsPostsInteractor
 import com.mobilejazz.kmmsample.core.feature.hackerposts.domain.model.HackerNewsPosts
 import kotlinx.coroutines.CoroutineScope
@@ -23,7 +23,7 @@ interface HackerPostsPresenter {
 }
 
 class HackerPostsDefaultPresenter(
-  private val view: WeakReference<HackerPostsPresenter.View>,
+  private val view: PresenterViewHolder<HackerPostsPresenter.View>,
   private val getHackerNewsPostsInteractor: GetHackerNewsPostsInteractor,
   private val logger: Logger
 ) : HackerPostsPresenter, CoroutineScope {
@@ -31,7 +31,7 @@ class HackerPostsDefaultPresenter(
   private val tag = "HackerPostsDefaultPresenter"
 
   override val coroutineContext: CoroutineContext
-    get() = job + Dispatchers.Main
+  get() = job + Dispatchers.Main
 
   private val job = Job()
 
@@ -57,6 +57,6 @@ class HackerPostsDefaultPresenter(
   }
 
   override fun onDetachView() {
-    view.clear()
+//    view.clear()
   }
 }

--- a/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/hackerposts/HackerPostsPresenter.kt
+++ b/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/hackerposts/HackerPostsPresenter.kt
@@ -13,7 +13,6 @@ import kotlin.coroutines.CoroutineContext
 
 interface HackerPostsPresenter {
   fun onViewLoaded()
-  fun onDetachView()
 
   interface View {
     fun onDisplayLoading()
@@ -54,9 +53,5 @@ class HackerPostsDefaultPresenter(
         }
       )
     }
-  }
-
-  override fun onDetachView() {
-//    view.clear()
   }
 }


### PR DESCRIPTION
PresenterViewHolder intent is to replace WeakReference as a view wrapper on the presenter.

On Android it wrap the view in a WeakReference and also clears the view when onDestroy is called.
On iOS the implementation just wraps the view in a WeakReference.
