### PR TITLE
Update dependencies

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,7 +1,7 @@
 const val android_min_sdk_version = 16
 const val android_target_sdk_version = 31
 
-const val kotlin_version = "1.6.10"
+const val kotlin_version = "1.6.21"
 
 const val ktor_version = "1.6.8"
 const val serialization_version = "1.3.2"
@@ -9,5 +9,5 @@ const val coroutines_version = "1.6.1-native-mt"
 const val sql_delight_version = "1.5.3"
 const val kotlinx_datetime_version = "0.3.2"
 const val uuid_lib_version = "0.3.1"
-const val mockmp_version = "1.4.0"
+const val mockmp_version = "1.5.0"
 const val mockk_version = "1.12.3"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,11 +3,11 @@ const val android_target_sdk_version = 31
 
 const val kotlin_version = "1.6.10"
 
-const val ktor_version = "1.6.7"
+const val ktor_version = "1.6.8"
 const val serialization_version = "1.3.2"
-const val coroutines_version = "1.6.0-native-mt"
+const val coroutines_version = "1.6.1-native-mt"
 const val sql_delight_version = "1.5.3"
 const val kotlinx_datetime_version = "0.3.2"
 const val uuid_lib_version = "0.3.1"
-const val mockmp_version = "1.2.0"
+const val mockmp_version = "1.4.0"
 const val mockk_version = "1.12.3"


### PR DESCRIPTION
Keeping kotlin version 1.6.10 until sql-delight 2.0 final release (as sql-delight 1.5.x is not working with kotlin 1.6.21)