### PR TITLE
KMM-7521 :: Feature :: Add version catalog & update dependencies

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,40 +1,5 @@
 // Android config
 const val android_min_sdk_version = 21
-const val android_target_sdk_version = 32
+const val android_target_sdk_version = 33
 
-// Project config
-const val kotlin_version = "1.7.10"
-const val android_gradle_plugin_version = "7.2.2"
-const val ktlint_version = "10.2.0"
 
-// KMM
-const val ktor_version = "2.0.3"
-const val serialization_version = "1.3.3"
-const val coroutines_version = "1.6.3-native-mt"
-const val sql_delight_version = "1.5.3"
-const val kotlinx_datetime_version = "0.4.0"
-const val uuid_lib_version = "0.5.0"
-const val ksp_version = "$kotlin_version-1.0.6"
-
-// Android
-const val app_compat_version = "1.4.2"
-const val coordinator_layout_version = "1.1.0"
-const val material_version = "1.6.1"
-const val constraint_layout_version = "2.1.4"
-const val gson_version = "2.8.9"
-const val bugfender_version = "3.0.16"
-const val compose_compiler_version = "1.3.0"
-const val compose_version = "1.2.0"
-const val compose_destinations_version = "1.6.13-beta"
-const val lifecycle_version = "2.5.1"
-const val core_ktx_version = "1.8.0"
-const val activity_compose_version = "1.5.1"
-
-// Testing
-const val mockmp_version = "1.8.1"
-const val mockk_version = "1.12.3"
-const val junit_version = "4.13.2"
-const val androidx_test_version = "1.4.0"
-const val androidx_junit_ktx_version = "1.1.3"
-const val roboelectric_version = "4.8.1"
-const val lifecycle_runtime_version = "2.5.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,6 @@ android.useAndroidX=true
 android.injected.studio.version.check=false
 
 #MPP
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableCInteropCommonization=true
 
 #Enable new Native Memory Model (required by Ktor 2.x)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,108 @@
+[versions]
+kotlin = "1.7.10"
+# Plugins
+androidGradlePlugin = "7.2.2"
+ksp = "1.7.10-1.0.6"
+ktlint = "11.0.0"
+gradleVersions = "0.41.0" # https://github.com/ben-manes/gradle-versions-plugin
+versionCatalogUpdate = "0.6.1" # https://github.com/littlerobots/version-catalog-update-plugin
+# KMM
+ktor = "2.1.1"
+serialization = "1.3.3"
+coroutines = "1.6.4"
+sqldelight = "1.5.3"
+datetime = "0.4.0"
+uuidLib = "0.5.0"
+# Android
+appCompat = "1.5.1"
+coordinatorLayout = "1.2.0"
+material = "1.6.1"
+constraintLayout = "2.1.4"
+gson = "2.9.1"
+bugfender = "3.0.16"
+composeCompiler = "1.3.0"
+compose = "1.2.1"
+composeDestinations = "1.6.20-beta"
+lifecycle = "2.5.1"
+coreKtx = "1.9.0"
+activityCompose = "1.5.1"
+# Testing
+mockmp = "1.9.0"
+mockk = "1.12.8"
+junit = "4.13.2"
+androidxTest = "1.4.0"
+androidxJunitKtx = "1.1.3"
+roboelectric = "4.9-alpha-1"
+lifecycleRuntime = "2.5.1"
+
+[libraries]
+# KMM
+ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+ktor-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serializationJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-ios = { module = "io.ktor:ktor-client-ios", version.ref = "ktor" }
+ktor-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
+ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+ktor-mockJvm = { module = "io.ktor:ktor-client-mock-jvm", version.ref = "ktor" }
+serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
+serialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serialization-cbor", version.ref = "serialization" }
+sqldelight-runtime = { module = "com.squareup.sqldelight:runtime", version.ref = "sqldelight" }
+sqldelight-nativeDriver = { module = "com.squareup.sqldelight:native-driver", version.ref = "sqldelight" }
+sqldelight-androidDriver = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqldelight" }
+sqldelight-sqliteDriver = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
+uuidLib = { module = "com.benasher44:uuid", version.ref = "uuidLib" }
+# Android
+appCompat = { module = "androidx.appcompat:appcompat", version.ref = "appCompat" }
+coordinatorLayout = { module = "androidx.coordinatorlayout:coordinatorlayout", version.ref = "coordinatorLayout" }
+constraintLayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintLayout" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+coreKtx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+bugfender = { module = "com.bugfender.sdk:android", version.ref = "bugfender" }
+composeUi = { module = "androidx.compose.ui:ui", version.ref = "compose" }
+composeUiToolingPreview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
+composeMaterial = { module = "androidx.compose.material:material", version.ref = "compose" }
+activityCompose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+lifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
+lifecycleViewModelCompose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+composeDestinations = { module = "io.github.raamcosta.compose-destinations:core", version.ref = "composeDestinations" }
+composeDestinationsKsp = { module = "io.github.raamcosta.compose-destinations:ksp", version.ref = "composeDestinations" }
+# JVM
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+# Testing
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinTestJunit = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+androidTest-core = { module = "androidx.test:core", version.ref = "androidxTest" }
+androidTest-runner = { module = "androidx.test:runner", version.ref = "androidxTest" }
+androidTest-rules = { module = "androidx.test:rules", version.ref = "androidxTest" }
+androidTest-junitKtx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidxJunitKtx" }
+androidTest-lifecycleRuntime = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "lifecycleRuntime" }
+roboelectric = { module = "org.robolectric:robolectric", version.ref = "roboelectric" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+[bundles]
+ktor = [
+    "ktor-contentNegotiation",
+    "ktor-core",
+    "ktor-logging",
+    "ktor-serializationJson",
+]
+serialization = [
+    "serialization-cbor",
+    "serialization-core",
+]
+
+[plugins]
+mockmp = { id = "org.kodein.mock.mockmp", version.ref = "mockmp" }
+sqldelight = { id = "com.squareup.sqldelight", version.ref = "sqldelight" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+gradleVersions = { id = "com.github.ben-manes.versions", version.ref = "gradleVersions"}
+versionCatalogUpdate = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdate"}

--- a/sample-android-compose/build.gradle.kts
+++ b/sample-android-compose/build.gradle.kts
@@ -1,8 +1,9 @@
+@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
   id("com.android.application")
   id("org.jetbrains.kotlin.android")
   // Used for Compose Destinations(https://github.com/raamcosta/compose-destinations)
-  id("com.google.devtools.ksp") version ksp_version
+  alias(libs.plugins.ksp)
 }
 
 android {
@@ -38,7 +39,7 @@ android {
     compose = true
   }
   composeOptions {
-    kotlinCompilerExtensionVersion = compose_compiler_version
+    kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
   }
   packagingOptions {
     resources {
@@ -58,18 +59,17 @@ android {
 dependencies {
   implementation(project(":sample-core"))
 
-  implementation("androidx.core:core-ktx:$core_ktx_version")
-  implementation("androidx.compose.ui:ui:$compose_version")
-  implementation("androidx.compose.material:material:$compose_version")
-  implementation("androidx.compose.ui:ui-tooling-preview:$compose_version")
-  implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version")
-  implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version")
-  implementation("androidx.activity:activity-compose:$activity_compose_version")
-  implementation("io.github.raamcosta.compose-destinations:core:$compose_destinations_version")
-  ksp("io.github.raamcosta.compose-destinations:ksp:$compose_destinations_version")
-  testImplementation("junit:junit:$junit_version")
-  androidTestImplementation("androidx.test.ext:junit:$androidx_junit_ktx_version")
-  androidTestImplementation("androidx.compose.ui:ui-test-junit4:$compose_version")
-  debugImplementation("androidx.compose.ui:ui-tooling:$compose_version")
-  debugImplementation("androidx.compose.ui:ui-test-manifest:$compose_version")
+  implementation(libs.coreKtx)
+  implementation(libs.composeUi)
+  implementation(libs.composeMaterial)
+  implementation(libs.composeUiToolingPreview)
+  implementation(libs.lifecycleRuntimeKtx)
+  implementation(libs.lifecycleViewModelCompose)
+  implementation(libs.activityCompose)
+  implementation(libs.composeDestinations)
+  ksp(libs.composeDestinationsKsp)
+}
+
+tasks.preBuild {
+  dependsOn(tasks.ktlintFormat)
 }

--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 dependencies {
   implementation(project(":sample-core"))
 
-  implementation("com.google.android.material:material:$material_version")
-  implementation("androidx.appcompat:appcompat:$app_compat_version")
-  implementation("androidx.constraintlayout:constraintlayout:$constraint_layout_version")
+  implementation(libs.material)
+  implementation(libs.appCompat)
+  implementation(libs.constraintLayout)
 }
 
 android {
@@ -34,4 +34,8 @@ android {
   buildFeatures {
     viewBinding = true
   }
+}
+
+tasks.preBuild {
+  dependsOn(tasks.ktlintFormat)
 }

--- a/sample-core/build.gradle.kts
+++ b/sample-core/build.gradle.kts
@@ -1,10 +1,11 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
+@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
   kotlin("multiplatform")
   kotlin("native.cocoapods")
   id("com.android.library")
-  kotlin("plugin.serialization")
+  kotlin("plugin.serialization") version libs.versions.kotlin.get()
 }
 
 version = "1.0"
@@ -38,6 +39,7 @@ kotlin {
     val commonMain by getting {
       dependencies {
         api(project(":harmony-kotlin"))
+//        api(libs.serialization.json)
       }
     }
     val commonTest by getting {
@@ -49,14 +51,14 @@ kotlin {
     val androidMain by getting {
       dependencies {
         api(project(":harmony-kotlin"))
-        implementation("io.ktor:ktor-client-okhttp:$ktor_version")
+        implementation(libs.ktor.okhttp)
       }
     }
     val androidTest by getting {
       dependencies {
         implementation(project(":harmony-kotlin"))
         implementation(kotlin("test-junit"))
-        implementation("junit:junit:$junit_version")
+        implementation(libs.junit)
       }
     }
     val iosX64Main by getting
@@ -68,7 +70,7 @@ kotlin {
       iosArm64Main.dependsOn(this)
       iosSimulatorArm64Main.dependsOn(this)
       dependencies {
-        implementation("io.ktor:ktor-client-ios:$ktor_version")
+        implementation(libs.ktor.ios)
       }
     }
 
@@ -81,6 +83,10 @@ kotlin {
       iosArm64Test.dependsOn(this)
       iosSimulatorArm64Test.dependsOn(this)
     }
+  }
+
+  tasks.preBuild {
+    dependsOn(tasks.ktlintFormat)
   }
 }
 

--- a/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/ApplicationProvider.kt
+++ b/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/ApplicationProvider.kt
@@ -9,7 +9,6 @@ import com.mobilejazz.kmmsample.core.screen.mvi.ViewModelComponent
 import com.mobilejazz.kmmsample.core.screen.mvi.ViewModelDefaultModule
 import com.mobilejazz.kmmsample.core.screen.mvp.PresenterComponent
 import com.mobilejazz.kmmsample.core.screen.mvp.PresenterDefaultModule
-
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.cbor.Cbor

--- a/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/mvi/ViewModelProvider.kt
+++ b/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/mvi/ViewModelProvider.kt
@@ -24,5 +24,4 @@ class ViewModelDefaultModule(
   override fun getHackerPostDetailViewModel(postId: Long): HackerPostDetailViewModel {
     return HackerPostDetailViewModel(postId, hackerNewsPostsComponent.getHackerNewsPostInteractor(), logger)
   }
-
 }

--- a/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/mvi/hackerPostDetail/HackerPostDetailViewModel.kt
+++ b/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/mvi/hackerPostDetail/HackerPostDetailViewModel.kt
@@ -43,7 +43,8 @@ class HackerPostDetailViewModel(
         },
         ifRight = {
           _viewState.value = HackerPostDetailViewState.Content(it)
-        })
+        }
+      )
     }
   }
 
@@ -54,5 +55,4 @@ class HackerPostDetailViewModel(
       }
     }
   }
-
 }

--- a/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/mvi/hackerPosts/HackerPostsViewModel.kt
+++ b/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/mvi/hackerPosts/HackerPostsViewModel.kt
@@ -27,7 +27,7 @@ sealed class HackerPostsViewState : ViewState {
   ) : HackerPostsViewState()
 }
 
-sealed class HackerPostsNavigation: Navigation {
+sealed class HackerPostsNavigation : Navigation {
   data class ToDetail constructor(val id: Long) : HackerPostsNavigation()
 }
 
@@ -53,7 +53,8 @@ class HackerPostsViewModel(
         },
         ifRight = {
           _viewState.value = HackerPostsViewState.Content(it)
-        })
+        }
+      )
     }
   }
 
@@ -69,5 +70,4 @@ class HackerPostsViewModel(
       }
     }
   }
-
 }

--- a/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/mvp/PresenterProvider.kt
+++ b/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/screen/mvp/PresenterProvider.kt
@@ -8,7 +8,6 @@ import com.mobilejazz.kmmsample.core.screen.mvp.hackerPostDetailPresenter.Hacker
 import com.mobilejazz.kmmsample.core.screen.mvp.hackerPosts.HackerPostsDefaultPresenter
 import com.mobilejazz.kmmsample.core.screen.mvp.hackerPosts.HackerPostsPresenter
 
-
 interface PresenterComponent {
   fun getHackerPostsPresenter(view: HackerPostsPresenter.View): HackerPostsPresenter
   fun getHackerPostDetailPresenter(view: HackerPostDetailPresenter.View): HackerPostDetailPresenter

--- a/sample-ios/Pods/Pods.xcodeproj/project.pbxproj
+++ b/sample-ios/Pods/Pods.xcodeproj/project.pbxproj
@@ -210,8 +210,8 @@
 		BFDFE7DC352907FC980B868725387E98 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1240;
+				LastSwiftUpdateCheck = 1300;
+				LastUpgradeCheck = 1300;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 10.0";


### PR DESCRIPTION
The objective of this PR is to implement a default [version catalog](https://docs.gradle.org/current/userguide/platforms.html) as this is the gradle built-in way of declaring dependencies. 

This will allow us to explore the possibility of publishing those dependencies as a [plugin](https://docs.gradle.org/current/userguide/platforms.html#sec:version-catalog-plugin) for the apps using harmony-library to depend on it (to avoid updating all the dependencies manually when updating harmony).

Changes on this PR:

- Add version catalog under `gradle/libs.versions.toml` (Depenendencies.kt shouln't be used anymore for declaring versions)
- Add [version-catalog-update-plugin](https://github.com/littlerobots/version-catalog-update-plugin)
  - From now on you can update dependencies using `./gradlew versionCatalogUpdate` and double-checking changes on toml file.
- Update dependencies
  - kotlinx.serialization was not updated due to [this](https://github.com/Kotlin/kotlinx.serialization/issues/2024) issue

**Merge / Pull request information:**

* Asana task link: https://app.asana.com/0/1109863238977521/1203021889811159/f
