### PR TITLE
KMM-6908 :: Feature :: Make public NetworkQuery extension functions

### DIFF
--- a/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/NetworkQueryToKtorExtensions.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/NetworkQueryToKtorExtensions.kt
@@ -15,7 +15,12 @@ import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.http.contentType
 
-internal suspend fun NetworkQuery.executeKtorRequest(httpClient: HttpClient, baseUrl: String, globalHeaders: List<Pair<String, String>>): String {
+/**
+ * Executes a Ktor request using the information contained in the query.
+ *
+ * **IMPORTANT:** This method is intended to be used only be used inside a Network DataSource
+ */
+suspend fun NetworkQuery.executeKtorRequest(httpClient: HttpClient, baseUrl: String, globalHeaders: List<Pair<String, String>>): String {
   val query = this
   return httpClient.request {
     method = query.method.mapToKtorMethod()
@@ -55,8 +60,10 @@ internal suspend fun NetworkQuery.executeKtorRequest(httpClient: HttpClient, bas
 
 /**
  * Creates a url using Ktor URLBuilder with baseUrl + path + url params
+ *
+ * **IMPORTANT:** This method is intended to be used only be used inside a Network DataSource
  */
-private fun NetworkQuery.generateKtorUrl(baseUrl: String): Url {
+fun NetworkQuery.generateKtorUrl(baseUrl: String): Url {
 
   val sanitizedBaseUrl = baseUrl.removeSuffix("/")
   val sanitizedPaths = this.path.split("/").filter { it.isNotEmpty() }.joinToString(separator = "/", prefix = "/")
@@ -82,8 +89,10 @@ private fun generateKtorUrlParams(params: List<Pair<String, String>>): Parameter
 
 /**
  * Transforms query method to Ktor method
+ *
+ * **IMPORTANT:** This method is intended to be used only be used inside a Network DataSource
  */
-private fun NetworkQuery.Method.mapToKtorMethod(): HttpMethod {
+fun NetworkQuery.Method.mapToKtorMethod(): HttpMethod {
   return when (this) {
     is NetworkQuery.Method.Get -> HttpMethod.Get
     is NetworkQuery.Method.Post -> HttpMethod.Post


### PR DESCRIPTION
This PR makes NetworkQuery extensions public as they can be useful for doing custom Network data sources.

**Merge / Pull request information:**

* Asana task link: https://app.asana.com/0/1109863238977521/1203241848856908
