### PR TITLE
KMM-7521 :: Feature :: Decrease memory usage on GenericNetworkDataSource

### DIFF
--- a/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/IgnoreNetworkResponseDecoder.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/IgnoreNetworkResponseDecoder.kt
@@ -1,0 +1,32 @@
+package com.harmony.kotlin.data.datasource.network
+
+import io.ktor.client.statement.HttpResponse
+
+/**
+ * Helper class that ignores [HttpResponse] body and just return [Unit].
+ * This class is for internal use only, for external use please use [IgnoreNetworkResponseDecoder] that has proper typing to avoid issues.
+ */
+internal class IgnoreNetworkResponseDecoderOfAnyType<T> : NetworkResponseDecoder<T>() {
+  @Suppress("UNCHECKED_CAST")
+  override suspend fun decode(httpResponse: HttpResponse): T {
+    return Unit as T
+  }
+
+  override suspend fun decodeList(httpResponse: HttpResponse): List<T> {
+    return emptyList()
+  }
+}
+
+/**
+ * Helper class that ignores [HttpResponse] body and just return [Unit].
+ */
+class IgnoreNetworkResponseDecoder internal constructor() : NetworkResponseDecoder<Unit>() {
+  @Suppress("UNCHECKED_CAST")
+  override suspend fun decode(httpResponse: HttpResponse) {
+    return
+  }
+
+  override suspend fun decodeList(httpResponse: HttpResponse): List<Unit> {
+    return emptyList()
+  }
+}

--- a/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/NetworkQueryToKtorExtensions.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/NetworkQueryToKtorExtensions.kt
@@ -5,7 +5,7 @@ import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.request.url
-import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.utils.EmptyContent
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
@@ -20,7 +20,7 @@ import io.ktor.http.contentType
  *
  * **IMPORTANT:** This method is intended to be used only be used inside a Network DataSource
  */
-suspend fun NetworkQuery.executeKtorRequest(httpClient: HttpClient, baseUrl: String, globalHeaders: List<Pair<String, String>>): String {
+suspend fun NetworkQuery.executeKtorRequest(httpClient: HttpClient, baseUrl: String, globalHeaders: List<Pair<String, String>>): HttpResponse {
   val query = this
   return httpClient.request {
     method = query.method.mapToKtorMethod()
@@ -55,7 +55,7 @@ suspend fun NetworkQuery.executeKtorRequest(httpClient: HttpClient, baseUrl: Str
         }
       }
     }
-  }.bodyAsText()
+  }
 }
 
 /**

--- a/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/NetworkResponseDecoder.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/NetworkResponseDecoder.kt
@@ -1,0 +1,18 @@
+package com.harmony.kotlin.data.datasource.network
+
+import io.ktor.client.statement.HttpResponse
+
+/**
+ * Helper class to decode a [HttpResponse] into an object.
+ */
+abstract class NetworkResponseDecoder<T> {
+  /**
+   * Decodes a [HttpResponse] into a [T] object.
+   */
+  internal abstract suspend fun decode(httpResponse: HttpResponse): T
+
+  /**
+   * Decodes a [HttpResponse] into a [List] of [T] objects.
+   */
+  internal abstract suspend fun decodeList(httpResponse: HttpResponse): List<T>
+}

--- a/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/SerializedNetworkResponseDecoder.kt
+++ b/harmony-kotlin/src/commonMain/kotlin/com/harmony/kotlin/data/datasource/network/SerializedNetworkResponseDecoder.kt
@@ -1,0 +1,17 @@
+package com.harmony.kotlin.data.datasource.network
+
+import io.ktor.client.statement.HttpResponse
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.StringFormat
+
+/**
+ * Helper class that decodes [HttpResponse] body using [StringFormat] and [KSerializer].
+ * @param stringFormat [StringFormat] - the format from which the data is decoded. Json, XML, etc.
+ * @param serializer [KSerializer] - serializer that is used to decode the data.
+ */
+expect class SerializedNetworkResponseDecoder<T> (stringFormat: StringFormat, serializer: KSerializer<T>) : NetworkResponseDecoder<T> {
+
+  override suspend fun decode(httpResponse: HttpResponse): T
+
+  override suspend fun decodeList(httpResponse: HttpResponse): List<T>
+}

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/network/GetNetworkDataSourceTests.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/network/GetNetworkDataSourceTests.kt
@@ -341,8 +341,7 @@ class GetNetworkDataSourceTests : BaseTest() {
   ) = GetNetworkDataSource(
     url = baseUrl,
     httpClient = HttpClient(engine = mockEngine),
-    serializer = serializer,
-    json = Json,
+    networkResponseDecoder = SerializedNetworkResponseDecoder(Json, serializer),
     globalHeaders = globalHeaders,
     exceptionMapper
   )

--- a/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/network/PutNetworkDataSourceTest.kt
+++ b/harmony-kotlin/src/commonTest/kotlin/com/harmony/kotlin/data/datasource/network/PutNetworkDataSourceTest.kt
@@ -278,6 +278,28 @@ class PutNetworkDataSourceTest : BaseTest() {
   }
 
   @Test
+  fun `should send PUT request and get Unit when using IgnoreNetworkResponseDecoder`() = runTest {
+    val mockEngine = mockEngine(response = "") {
+      requestSpy = it
+    }
+    val contentTypeQuery = NetworkQuery(
+      NetworkQuery.Method.Put(NetworkQuery.ContentType.Json(objectToSend)),
+      pathUrl
+    )
+    val putNetworkDataSource = PutNetworkDataSource(
+      baseUrl, mockHttpClient(mockEngine), IgnoreNetworkResponseDecoder(), emptyList()
+    )
+
+    val putResult = putNetworkDataSource.put(contentTypeQuery, null)
+
+    with(requestSpy) {
+      assertNotNull(this)
+      assertEquals(HttpMethod.Put, method)
+    }
+    assertEquals(Unit, putResult)
+  }
+
+  @Test
   fun `should send PUT request and get Unit list when using Unit serializer for put all`() = runTest {
     val mockEngine = mockEngine(response = "") {
       requestSpy = it
@@ -296,6 +318,24 @@ class PutNetworkDataSourceTest : BaseTest() {
   }
 
   @Test
+  fun `should send PUT request and get Unit list when using IgnoreNetworkResponseDecoder for put all`() = runTest {
+    val mockEngine = mockEngine(response = "") {
+      requestSpy = it
+    }
+    val contentTypeQuery = NetworkQuery(
+      NetworkQuery.Method.Put(NetworkQuery.ContentType.Json(listOf(objectToSend))),
+      pathUrl
+    )
+    val putNetworkDataSource = PutNetworkDataSource(
+      baseUrl, mockHttpClient(mockEngine), IgnoreNetworkResponseDecoder(), emptyList()
+    )
+
+    val putResult = putNetworkDataSource.putAll(contentTypeQuery, null)
+
+    assertEquals(listOf(), putResult)
+  }
+
+  @Test
   fun `should send PUT request and get Unit list when using Unit serializer for put`() = runTest {
     val mockEngine = mockEngine(response = "") {
       requestSpy = it
@@ -306,6 +346,24 @@ class PutNetworkDataSourceTest : BaseTest() {
     )
     val putNetworkDataSource = PutNetworkDataSource(
       baseUrl, mockHttpClient(mockEngine), Unit.serializer(), Json, emptyList()
+    )
+
+    val putResult = putNetworkDataSource.put(contentTypeQuery, null)
+
+    assertEquals(Unit, putResult)
+  }
+
+  @Test
+  fun `should send PUT request and get Unit list when using IgnoreNetworkResponseDecoder for put`() = runTest {
+    val mockEngine = mockEngine(response = "") {
+      requestSpy = it
+    }
+    val contentTypeQuery = NetworkQuery(
+      NetworkQuery.Method.Put(NetworkQuery.ContentType.Json(listOf(objectToSend))),
+      pathUrl
+    )
+    val putNetworkDataSource = PutNetworkDataSource(
+      baseUrl, mockHttpClient(mockEngine), IgnoreNetworkResponseDecoder(), emptyList()
     )
 
     val putResult = putNetworkDataSource.put(contentTypeQuery, null)
@@ -473,6 +531,6 @@ class PutNetworkDataSourceTest : BaseTest() {
     globalHeaders: List<Pair<String, String>> = emptyList(),
     exceptionMapper: Mapper<Exception, Exception> = IdentityMapper()
   ) = PutNetworkDataSource(
-    baseUrl, mockHttpClient(mockEngine), Dummy.serializer(), Json, globalHeaders, exceptionMapper
+    baseUrl, mockHttpClient(mockEngine), SerializedNetworkResponseDecoder(Json, Dummy.serializer()), globalHeaders, exceptionMapper
   )
 }

--- a/harmony-kotlin/src/iosMain/kotlin/com/harmony/kotlin/data/datasource/network/SerializedNetworkResponseDecoder.kt
+++ b/harmony-kotlin/src/iosMain/kotlin/com/harmony/kotlin/data/datasource/network/SerializedNetworkResponseDecoder.kt
@@ -1,0 +1,23 @@
+package com.harmony.kotlin.data.datasource.network
+
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.StringFormat
+import kotlinx.serialization.builtins.ListSerializer
+
+actual class SerializedNetworkResponseDecoder<T> actual constructor(private val stringFormat: StringFormat, private val serializer: KSerializer<T>) :
+  NetworkResponseDecoder<T>() {
+  actual override suspend fun decode(httpResponse: HttpResponse): T {
+    return decode(httpResponse, serializer)
+  }
+
+  actual override suspend fun decodeList(httpResponse: HttpResponse): List<T> {
+    return decode(httpResponse, ListSerializer(serializer))
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private suspend fun <V> decode(httpResponse: HttpResponse, serializer: KSerializer<V>): V {
+    return stringFormat.decodeFromString(serializer, httpResponse.bodyAsText())
+  }
+}

--- a/harmony-kotlin/src/jvmAndroidCommon/kotlin/com/harmony/kotlin/data/datasource/network/SerializedNetworkResponseDecoder.kt
+++ b/harmony-kotlin/src/jvmAndroidCommon/kotlin/com/harmony/kotlin/data/datasource/network/SerializedNetworkResponseDecoder.kt
@@ -1,0 +1,30 @@
+package com.harmony.kotlin.data.datasource.network
+
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.StringFormat
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+
+actual class SerializedNetworkResponseDecoder<T> actual constructor(private val stringFormat: StringFormat, private val serializer: KSerializer<T>) :
+  NetworkResponseDecoder<T>() {
+  actual override suspend fun decode(httpResponse: HttpResponse): T {
+    return decode(httpResponse, serializer)
+  }
+
+  actual override suspend fun decodeList(httpResponse: HttpResponse): List<T> {
+    return decode(httpResponse, ListSerializer(serializer))
+  }
+
+  private suspend fun <V> decode(httpResponse: HttpResponse, serializer: KSerializer<V>): V {
+    return if (stringFormat is Json) {
+      stringFormat.decodeFromStream(serializer, httpResponse.bodyAsChannel().toInputStream())
+    } else {
+      stringFormat.decodeFromString(serializer, httpResponse.bodyAsText())
+    }
+  }
+}

--- a/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/feature/hackerposts/HackerNewsPostsProvider.kt
+++ b/sample-core/src/commonMain/kotlin/com/mobilejazz/kmmsample/core/feature/hackerposts/HackerNewsPostsProvider.kt
@@ -7,6 +7,7 @@ import com.harmony.kotlin.data.datasource.VoidPutDataSource
 import com.harmony.kotlin.data.datasource.cache.CacheSQLConfiguration
 import com.harmony.kotlin.data.datasource.cache.CacheSQLStorageDataSource
 import com.harmony.kotlin.data.datasource.network.GetNetworkDataSource
+import com.harmony.kotlin.data.datasource.network.SerializedNetworkResponseDecoder
 import com.harmony.kotlin.data.datasource.toGetRepository
 import com.harmony.kotlin.data.mapper.CBORByteArrayToObject
 import com.harmony.kotlin.data.mapper.CBORObjectToByteArray
@@ -62,8 +63,10 @@ class HackerNewsPostsDefaultModule(
     val hackerPostsIdsNetworkDataSource = GetNetworkDataSource(
       networkConfiguration.baseUrl,
       networkConfiguration.httpClient,
-      ListSerializer(Long.serializer()),
-      networkConfiguration.json
+      SerializedNetworkResponseDecoder(
+        networkConfiguration.json,
+        ListSerializer(Long.serializer())
+      )
     )
 
     val hackerNewsQueryToNetworkQueryMapper = HackerNewsQueryToNetworkQueryMapper()
@@ -85,8 +88,10 @@ class HackerNewsPostsDefaultModule(
     val hackerPostsNetworkDataSource = GetNetworkDataSource(
       networkConfiguration.baseUrl,
       networkConfiguration.httpClient,
-      HackerNewsPostEntity.serializer(),
-      networkConfiguration.json
+      SerializedNetworkResponseDecoder(
+        networkConfiguration.json,
+        HackerNewsPostEntity.serializer()
+      )
     )
 
     val hackerNewsQueryToNetworkQuery = HackerNewsQueryToNetworkQueryMapper()


### PR DESCRIPTION
<!--
**Merge/Pull request title name template, please delete it before saving it**

Task_number :: Project :: Story :: Task_type(Feature|Feature Internal|Bug) :: Task_name

+info: https://harmony.mobilejazz.com/docs/best-practices/git-standardization
-->

* Asana task link: https://app.asana.com/0/1109863238977521/1203596738903595

**Merge / Pull request information:**
This PR originated due to memory usage issues using Generic Network DataSource. More details on the Asana task.

This PR improves memory consumption on Android (on iOS there is no alternative yet to parse data from a stream)

This PR includes:
- Created `NetworkResponseDecoder` that will be in charge of deserializing the response on the Generic Network DataSource.
  - Two implementations exist: `SerializedNetworkResponseDecoder` & `IgnoreNetworkResponseDecoder`
  - `SerializedNetworkResponseDecoder` is implemented as an expect/actual where the Android part deserializes the response from a stream (not having all the response in memory prior to deserialization).
  - This one is generic so you can use it to deserialize JSON, XML or any other supported format by kotlinx.serialization
- Created new constructors requiring `NetworkResponseDecoder`
- Deprecated previous constructors (they are still working as expected)
- Modified & created new tests

Additional details:
 - I've not implemented NetworkResponseDecoder as just simple mappers because I should return a ktor-specific stream object (`ByteReadChannel`) in our Generic Network DataSource.
 - I've tested in the problematic project and now memory issues are gone.
